### PR TITLE
Fix LICENSE.txt not being included in the generated .vsix

### DIFF
--- a/VisualRust/VisualRust.csproj
+++ b/VisualRust/VisualRust.csproj
@@ -174,6 +174,10 @@
     <None Include="Key.snk" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="..\LICENSE.txt">
+      <Link>LICENSE.txt</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="Resources\Package.ico" />
   </ItemGroup>
   <ItemGroup>

--- a/VisualRust/source.extension.vsixmanifest
+++ b/VisualRust/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     <Identity Id="40c1d2b5-528b-4966-a7b1-1974e3568abe" Version="1.0" Language="en-US" Publisher="The Piston Project" />
     <DisplayName>VisualRust</DisplayName>
     <Description>Visual Studio integration for the Rust programming language (http://www.rust-lang.org/)</Description>
-    <License>..\LICENSE.txt</License>
+    <License>LICENSE.txt</License>
   </Metadata>
   <Installation InstalledByMsi="false">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[12.0, 13.0)" />


### PR DESCRIPTION
Currently, .vsixmanifest references LICENSE.txt, but the project file doesn't include it. Consequently .vsix builds fine but fails during installation. This change fixes that.
