### PR TITLE
Small cleanups

### DIFF
--- a/VisualRust/RustLanguage.cs
+++ b/VisualRust/RustLanguage.cs
@@ -43,7 +43,7 @@ namespace VisualRust
 
         public override IScanner GetScanner(IVsTextLines buffer)
         {
-            throw new NotImplementedException();
+            return null;
         }
 
         public override string Name
@@ -53,7 +53,7 @@ namespace VisualRust
 
         public override AuthoringScope ParseSource(ParseRequest req)
         {
-            throw new NotImplementedException();
+            return null;
         }
     }
 }

--- a/VisualRust/VisualRustSmartIndent.cs
+++ b/VisualRust/VisualRustSmartIndent.cs
@@ -74,14 +74,6 @@ namespace VisualRust
                 {
                     return prevLine.GetText().TakeWhile(c2 => c2 == ' ').Count() + indentSize;
                 }
-                // The line before contains }, we dedent it
-                else if (toks.Any(tok => tok.Type == RustLexer.RustLexer.RBRACE))
-                {
-                    ed.MoveLineUp(false);
-                    ed.DecreaseLineIndent();
-                    ed.MoveLineDown(false);
-                    return Math.Max(0, prevLine.GetText().TakeWhile(c2 => c2 == ' ').Count() - indentSize);
-                }
             }
             // otherwise, there are no lines ending in braces before us.
             return null;


### PR DESCRIPTION
Stop trying to dedent lines, this belongs in a wholly different place and is buggy. Also stop throwing NotImplemented for Language service, just return null like a civilized implementation.
