### PR TITLE
Add support for project settings

### DIFF
--- a/Microsoft.VisualStudio.Project/CommonProjectNode.cs
+++ b/Microsoft.VisualStudio.Project/CommonProjectNode.cs
@@ -373,7 +373,7 @@ namespace Microsoft.VisualStudioTools.Project {
             return found;
         }
 
-        public virtual CommonProjectConfig MakeConfiguration(string activeConfigName) {
+        public virtual ProjectConfig MakeConfiguration(string activeConfigName) {
             return new CommonProjectConfig(this, activeConfigName);
         }
 

--- a/Microsoft.VisualStudio.Project/CommonPropertyPage.cs
+++ b/Microsoft.VisualStudio.Project/CommonPropertyPage.cs
@@ -26,6 +26,7 @@ namespace Microsoft.VisualStudioTools.Project {
     /// <summary>
     /// Base class for property pages based on a WinForm control.
     /// </summary>
+    [ComVisible(true)]
     public abstract class CommonPropertyPage : IPropertyPage {
         private IPropertyPageSite _site;
         private bool _dirty, _loading;

--- a/Microsoft.VisualStudio.Project/CommonPropertyPage.cs
+++ b/Microsoft.VisualStudio.Project/CommonPropertyPage.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudioTools.Project {
             Control.Size = new Size(r.right - r.left, r.bottom - r.top);
         }
 
-        void IPropertyPage.SetObjects(uint count, object[] punk) {
+        public virtual void SetObjects(uint count, object[] punk) {
             if (punk == null) {
                 return;
             }

--- a/Microsoft.VisualStudio.Project/ConfigProvider.cs
+++ b/Microsoft.VisualStudio.Project/ConfigProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudioTools.Project {
 
     [ComVisible(true)]
     internal abstract class ConfigProvider : IVsCfgProvider2 {
-        internal const string configString = " '$(Configuration)' == '{0}' ";
+        internal const string configString = " '$(Configuration)|$(Platform)' == '{0}|{1}' ";
         internal const string AnyCPUPlatform = "Any CPU";
         internal const string x86Platform = "x86";
 
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudioTools.Project {
             newConfig.AddProperty("OutputPath", CommonUtils.NormalizeDirectoryPath(Path.Combine(outputBasePath, name)));
 
             // Set the condition that will define the new configuration
-            string newCondition = String.Format(CultureInfo.InvariantCulture, configString, name);
+            string newCondition = String.Format(CultureInfo.InvariantCulture, configString, name, "default");
             newConfig.Condition = newCondition;
 
             NotifyOnCfgNameAdded(name);
@@ -200,7 +200,7 @@ namespace Microsoft.VisualStudioTools.Project {
             foreach (string config in configs) {
                 if (String.Compare(config, name, StringComparison.OrdinalIgnoreCase) == 0) {
                     // Create condition of config to remove
-                    string condition = String.Format(CultureInfo.InvariantCulture, configString, config);
+                    string condition = String.Format(CultureInfo.InvariantCulture, configString, config, "default");
 
                     foreach (ProjectPropertyGroupElement element in this.project.BuildProject.Xml.PropertyGroups) {
                         if (String.Equals(element.Condition, condition, StringComparison.OrdinalIgnoreCase)) {
@@ -364,7 +364,7 @@ namespace Microsoft.VisualStudioTools.Project {
         /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
         public virtual int RenameCfgsOfCfgName(string old, string newname) {
             // First create the condition that represent the configuration we want to rename
-            string condition = String.Format(CultureInfo.InvariantCulture, configString, old).Trim();
+            string condition = String.Format(CultureInfo.InvariantCulture, configString, old, "default").Trim();
 
             foreach (ProjectPropertyGroupElement config in this.project.BuildProject.Xml.PropertyGroups) {
                 // Only care about conditional property groups
@@ -376,7 +376,7 @@ namespace Microsoft.VisualStudioTools.Project {
                     continue;
 
                 // Change the name 
-                config.Condition = String.Format(CultureInfo.InvariantCulture, configString, newname);
+                config.Condition = String.Format(CultureInfo.InvariantCulture, configString, newname, "default");
                 // Update the name in our config list
                 if (configurationsList.ContainsKey(old)) {
                     ProjectConfig configuration = configurationsList[old];

--- a/Microsoft.VisualStudio.Project/ConfigProvider.cs
+++ b/Microsoft.VisualStudio.Project/ConfigProvider.cs
@@ -489,7 +489,7 @@ namespace Microsoft.VisualStudioTools.Project {
         /// Return the supported platform names.
         /// </summary>
         /// <returns>An array of supported platform names.</returns>
-        private string[] GetSupportedPlatformsFromProject() {
+        protected string[] GetSupportedPlatformsFromProject() {
             string platforms = this.ProjectMgr.BuildProject.GetPropertyValue(ProjectFileConstants.AvailablePlatforms);
 
             if (platforms == null) {
@@ -525,7 +525,7 @@ namespace Microsoft.VisualStudioTools.Project {
         /// <param name="platforms">An array of available platform names</param>
         /// <returns>A count of the actual number of platform names returned.</returns>
         /// <devremark>The platforms array is never null. It is assured by the callers.</devremark>
-        private static int GetPlatforms(uint celt, string[] names, uint[] actual, string[] platforms) {
+        protected static int GetPlatforms(uint celt, string[] names, uint[] actual, string[] platforms) {
             Utilities.ArgumentNotNull("platforms", platforms);
             if (names == null) {
                 if (actual == null || actual.Length == 0) {
@@ -566,7 +566,7 @@ namespace Microsoft.VisualStudioTools.Project {
         /// <summary>
         /// Get all the configurations in the project.
         /// </summary>
-        private string[] GetPropertiesConditionedOn(string constant) {
+        protected string[] GetPropertiesConditionedOn(string constant) {
             List<string> configurations = null;
             this.project.BuildProject.ReevaluateIfNecessary();
             this.project.BuildProject.ConditionedProperties.TryGetValue(constant, out configurations);

--- a/Microsoft.VisualStudio.Project/ProjectConfig.cs
+++ b/Microsoft.VisualStudio.Project/ProjectConfig.cs
@@ -138,7 +138,7 @@ namespace Microsoft.VisualStudioTools.Project {
                 throw Marshal.GetExceptionForHR(VSConstants.OLE_E_PROMPTSAVECANCELLED);
             }
 
-            string condition = String.Format(CultureInfo.InvariantCulture, ConfigProvider.configString, this.ConfigName);
+            string condition = String.Format(CultureInfo.InvariantCulture, ConfigProvider.configString, this.ConfigName, this.PlatformName);
 
             SetPropertyUnderCondition(propertyName, propertyValue, condition);
 
@@ -244,6 +244,17 @@ namespace Microsoft.VisualStudioTools.Project {
         public virtual int get_DisplayName(out string name) {
             name = DisplayName;
             return VSConstants.S_OK;
+        }
+
+        private string PlatformName {
+            get {
+                string[] platform = new string[1];
+                uint[] actual = new uint[1];
+                IVsCfgProvider provider;
+                ErrorHandler.ThrowOnFailure(project.GetCfgProvider(out provider));
+                ErrorHandler.ThrowOnFailure(((IVsCfgProvider2)provider).GetPlatformNames(1, platform, actual));
+                return platform[0];
+            }
         }
 
         private string DisplayName {

--- a/VisualRust.Build/Rustc.cs
+++ b/VisualRust.Build/Rustc.cs
@@ -153,6 +153,16 @@ namespace VisualRust.Build
         /// </summary>
         public string CodegenOptions { get; set; }
 
+        private bool? lto;
+        /// <summary>
+        /// Sets -C lto option. Default value is false.
+        /// </summary>
+        public bool LTO
+        {
+            get { return lto.HasValue ? lto.Value : false; }
+            set { lto = value; }
+        }
+
         [Required]
         public string WorkingDirectory { get; set; }
 
@@ -211,6 +221,8 @@ namespace VisualRust.Build
                 sb.AppendFormat(" -D {0}", String.Join(",", LintsAsDenied));
             if(LintsAsForbidden.Length > 0)
                 sb.AppendFormat(" -F {0}", String.Join(",", LintsAsForbidden));
+            if (lto.HasValue && lto.Value)
+                sb.AppendFormat(" -C lto");
             if (CodegenOptions != null)
                 sb.AppendFormat(" -C {0}", CodegenOptions);
             sb.AppendFormat(" {0}", Input);
@@ -224,7 +236,6 @@ namespace VisualRust.Build
                     Log.LogError("Could not find a Rust instalation that can compile target {0}.", target);
                 return false;
             }
-            // Currently we hope that rustc is in the path
             var psi = new ProcessStartInfo()
             {
                 CreateNoWindow = true,

--- a/VisualRust.Build/Rustc.cs
+++ b/VisualRust.Build/Rustc.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.Build.Framework;
+using System.IO;
 
 namespace VisualRust.Build
 {
@@ -178,6 +179,12 @@ namespace VisualRust.Build
 
         private bool ExecuteInner()
         {
+            string rustBinPath = VisualRust.Shared.Environment.FindInstallPath(VisualRust.Shared.Environment.DefaultTarget);
+            if(rustBinPath == null)
+            {
+                Log.LogError("No Rust compiler installed.");
+                return false;
+            }
             StringBuilder sb = new StringBuilder();
             if (ConfigFlags.Length > 0)
                 sb.AppendFormat(" --cfg {0}", String.Join(",", ConfigFlags));
@@ -218,12 +225,13 @@ namespace VisualRust.Build
             var psi = new ProcessStartInfo()
             {
                 CreateNoWindow = true,
-                FileName = "rustc.exe",
+                FileName =  Path.Combine(rustBinPath, "rustc.exe"),
                 UseShellExecute = false,
                 WorkingDirectory = WorkingDirectory,
                 Arguments = sb.ToString(),
                 RedirectStandardError = true
             };
+            Log.LogCommandLine(String.Join(" ", psi.FileName, psi.Arguments));
             try
             {
                 Process process = new Process();

--- a/VisualRust.Build/VisualRust.Rust.targets
+++ b/VisualRust.Build/VisualRust.Rust.targets
@@ -1,25 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
-  <PropertyGroup>
-    <VisualRustTasksPath>$(MSBuildExtensionsPath)\VisualRust</VisualRustTasksPath>
-  </PropertyGroup>
 
   <UsingTask AssemblyFile="$(VisualRustTasksPath)\VisualRust.Build.dll"
              TaskFactory="RustcFactory"
              TaskName="Rustc"/>
 
+  <PropertyGroup>
+    <VisualRustTasksPath>$(MSBuildExtensionsPath)\VisualRust</VisualRustTasksPath>
+    <CrateType Condition="'$(CrateType)' != 'library'">exe</CrateType>
+    <_EntryPoint Condition="'$(CrateType)'=='exe'">src\main.rs</_EntryPoint>
+    <_EntryPoint Condition="'$(CrateType)'=='library'">src\lib.rs</_EntryPoint>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <PlatformTarget Condition="'$(PlatformTarget)' == ''" >default</PlatformTarget>
+    <OutDir Condition="'$(PlatformTarget)' == 'default'" >target\$(Configuration)\</OutDir>
+    <OutDir Condition="'$(PlatformTarget)' != 'default'" >target\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <LinkTimeOptimization Condition="'$(LinkTimeOptimization)' == ''">false</LinkTimeOptimization>
+    <_DebugLevel Condition="'$(DebugSymbols)' == 'true'">2</_DebugLevel>
+    <_DebugLevel Condition="'$(DebugSymbols)' != 'true'">0</_DebugLevel>
+  </PropertyGroup>
+
   <Target Name="CoreCompile">
-    <PropertyGroup>
-      <EntryPoint Condition="'$(EntryPoint)'=='' and '$(OutputType)'=='library'">src\lib.rs</EntryPoint>
-      <EntryPoint Condition="'$(EntryPoint)'=='' and ('$(OutputType)'=='exe' or '$(OutputType)'=='winexe')">src\main.rs</EntryPoint>
-      <CompilerOutput Condition="'$(OutputType)'=='library'">$(CompilerOutput);lib</CompilerOutput>
-      <CompilerOutput Condition="'$(OutputType)'=='exe' or '$(OutputType)'=='winexe'">$(CompilerOutput);bin</CompilerOutput>
-    </PropertyGroup>
-    <Rustc Input="$(EntryPoint)"
-           OutputFile="$(IntermediateOutputPath)$(TargetFileName)"
+    <Rustc Input="$(_EntryPoint)"
+           OutputDirectory="$(OutDir)"
            WorkingDirectory="$(ProjectDir)"
-           CrateType="$(CompilerOutput)"/>
+           CrateName="$(CrateName)"
+           CrateType="$(CrateType)"
+           LTO="$(LinkTimeOptimization)"
+           DebugInfo="$(_DebugLevel)"
+           OptimizationLevel="$(OptimizationLevel)"
+           TargetTriple="$(PlatformTarget)"/>
   </Target>
   <Target Name="CreateManifestResourceNames"/>
 </Project>

--- a/VisualRust.Build/VisualRust.Rust.targets
+++ b/VisualRust.Build/VisualRust.Rust.targets
@@ -11,14 +11,16 @@
     <_EntryPoint Condition="'$(OutputType)'=='library'">src\lib.rs</_EntryPoint>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <PlatformTarget Condition="'$(PlatformTarget)' == ''" >default</PlatformTarget>
-    <OutputPath>obj\$(PlatformTarget)\$(Configuration)\</OutputPath>
+    <OutputPath Condition="'$(PlatformTarget)' == 'default'" >target\$(Configuration)\</OutputPath>
+    <OutputPath Condition="'$(PlatformTarget)' != 'default'" >target\$(PlatformTarget)\$(Configuration)\</OutputPath>
     <LinkTimeOptimization Condition="'$(LinkTimeOptimization)' == ''">false</LinkTimeOptimization>
+    <CrateName Condition="'$(CrateName)' ==''">$(MSBuildProjectName)</CrateName>
     <AssemblyName>$(CrateName)</AssemblyName>
   </PropertyGroup>
 
   <Target Name="CoreCompile">
     <Rustc Input="$(_EntryPoint)"
-           OutputDirectory="$(OutDir)"
+           OutputDirectory="$(IntermediateOutputPath)"
            WorkingDirectory="$(ProjectDir)"
            CrateName="$(CrateName)"
            CrateType="$(OutputType)"
@@ -27,6 +29,7 @@
            OptimizationLevel="$(OptimizationLevel)"
            TargetTriple="$(PlatformTarget)"/>
   </Target>
-  <Target Name="CreateManifestResourceNames"/>
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+  <Target Name="GetFrameworkPaths"/>
+  <Target Name="CreateManifestResourceNames"/>
 </Project>

--- a/VisualRust.Build/VisualRust.Rust.targets
+++ b/VisualRust.Build/VisualRust.Rust.targets
@@ -1,23 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
-
   <UsingTask AssemblyFile="$(VisualRustTasksPath)\VisualRust.Build.dll"
              TaskFactory="RustcFactory"
              TaskName="Rustc"/>
 
   <PropertyGroup>
     <VisualRustTasksPath>$(MSBuildExtensionsPath)\VisualRust</VisualRustTasksPath>
-    <CrateType Condition="'$(CrateType)' != 'library'">exe</CrateType>
-    <_EntryPoint Condition="'$(CrateType)'=='exe'">src\main.rs</_EntryPoint>
-    <_EntryPoint Condition="'$(CrateType)'=='library'">src\lib.rs</_EntryPoint>
+    <OutputType Condition="'$(OutputType)' != 'library'">exe</OutputType>
+    <_EntryPoint Condition="'$(OutputType)'=='exe'">src\main.rs</_EntryPoint>
+    <_EntryPoint Condition="'$(OutputType)'=='library'">src\lib.rs</_EntryPoint>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <PlatformTarget Condition="'$(PlatformTarget)' == ''" >default</PlatformTarget>
-    <OutDir Condition="'$(PlatformTarget)' == 'default'" >target\$(Configuration)\</OutDir>
-    <OutDir Condition="'$(PlatformTarget)' != 'default'" >target\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutputPath>obj\$(PlatformTarget)\$(Configuration)\</OutputPath>
     <LinkTimeOptimization Condition="'$(LinkTimeOptimization)' == ''">false</LinkTimeOptimization>
-    <_DebugLevel Condition="'$(DebugSymbols)' == 'true'">2</_DebugLevel>
-    <_DebugLevel Condition="'$(DebugSymbols)' != 'true'">0</_DebugLevel>
+    <AssemblyName>$(CrateName)</AssemblyName>
   </PropertyGroup>
 
   <Target Name="CoreCompile">
@@ -25,11 +21,12 @@
            OutputDirectory="$(OutDir)"
            WorkingDirectory="$(ProjectDir)"
            CrateName="$(CrateName)"
-           CrateType="$(CrateType)"
+           CrateType="$(OutputType)"
            LTO="$(LinkTimeOptimization)"
-           DebugInfo="$(_DebugLevel)"
+           DebugInfo="$(DebugSymbols)"
            OptimizationLevel="$(OptimizationLevel)"
            TargetTriple="$(PlatformTarget)"/>
   </Target>
   <Target Name="CreateManifestResourceNames"/>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 </Project>

--- a/VisualRust.Project/Configuration/Application.Custom.cs
+++ b/VisualRust.Project/Configuration/Application.Custom.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.VisualStudioTools.Project;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VisualRust.Shared;
+
+namespace VisualRust.Project.Configuration
+{
+    partial class Application
+    {
+        private static BuildOutputType OutputTypeFromString(string p)
+        {
+            return BuildOutputTypeExtension.Parse(p);
+        }
+
+        private string OutputTypeToString(BuildOutputType OutputType)
+        {
+            return OutputType.ToBuildString();
+        }
+    }
+}

--- a/VisualRust.Project/Configuration/Application.cs
+++ b/VisualRust.Project/Configuration/Application.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using Microsoft.VisualStudioTools.Project;
 
@@ -18,7 +19,7 @@ namespace VisualRust.Project.Configuration
                 if(temp != null)
                     temp(this, new EventArgs());
             }
-        }
+        } 
         private System.String crateName;
         public System.String CrateName
         {
@@ -30,7 +31,7 @@ namespace VisualRust.Project.Configuration
                 if(temp != null)
                     temp(this, new EventArgs());
             }
-        }
+        } 
 
         public bool HasChangedFrom(Application obj)
         {
@@ -48,6 +49,7 @@ namespace VisualRust.Project.Configuration
                 CrateName = this.CrateName,
             };
         }
+
 
         public static Application LoadFrom(CommonProjectNode proj)
         {

--- a/VisualRust.Project/Configuration/Application.cs
+++ b/VisualRust.Project/Configuration/Application.cs
@@ -6,16 +6,37 @@ namespace VisualRust.Project.Configuration
 {
     partial class Application
     {
-        private System.String crateName;
-        public System.String CrateName { get { return crateName; }  set { crateName = value; } }
+        public event EventHandler Changed;
         private VisualRust.Shared.BuildOutputType outputType;
-        public VisualRust.Shared.BuildOutputType OutputType { get { return outputType; }  set { outputType = value; } }
-
-        public bool IsEqual(Application obj)
+        public VisualRust.Shared.BuildOutputType OutputType
         {
-            return true
-                && EqualityComparer<System.String>.Default.Equals(CrateName, obj.CrateName)
-                && EqualityComparer<VisualRust.Shared.BuildOutputType>.Default.Equals(OutputType, obj.OutputType)
+            get { return outputType; }
+            set
+            {
+                outputType = value;
+                var temp = Changed;
+                if(temp != null)
+                    temp(this, new EventArgs());
+            }
+        }
+        private System.String crateName;
+        public System.String CrateName
+        {
+            get { return crateName; }
+            set
+            {
+                crateName = value;
+                var temp = Changed;
+                if(temp != null)
+                    temp(this, new EventArgs());
+            }
+        }
+
+        public bool HasChangedFrom(Application obj)
+        {
+            return false
+            || (!EqualityComparer<VisualRust.Shared.BuildOutputType>.Default.Equals(OutputType, obj.OutputType))
+            || (!EqualityComparer<System.String>.Default.Equals(CrateName, obj.CrateName))
             ;
         }
 
@@ -23,23 +44,23 @@ namespace VisualRust.Project.Configuration
         {
             return new Application
             {
-                CrateName = this.CrateName,
                 OutputType = this.OutputType,
+                CrateName = this.CrateName,
             };
         }
 
         public static Application LoadFrom(CommonProjectNode proj)
         {
             var x = new Application();
-            Utils.FromString(proj.GetUnevaluatedProperty("CrateName"), out x.crateName);
             x.OutputType = OutputTypeFromString(proj.GetUnevaluatedProperty("PlatformTarget"));
+            Utils.FromString(proj.GetUnevaluatedProperty("CrateName"), out x.crateName);
             return x;
         }
 
         public void SaveTo(CommonProjectNode proj)
         {
-            proj.SetProjectProperty("CrateName", CrateName.ToString());
             proj.SetProjectProperty("PlatformTarget", OutputTypeToString(OutputType));
+            proj.SetProjectProperty("CrateName", CrateName.ToString());
         }
     }
 }

--- a/VisualRust.Project/Configuration/Application.cs
+++ b/VisualRust.Project/Configuration/Application.cs
@@ -6,10 +6,16 @@ namespace VisualRust.Project.Configuration
 {
     partial class Application
     {
+        private System.String crateName;
+        public System.String CrateName { get { return crateName; }  set { crateName = value; } }
+        private VisualRust.Shared.BuildOutputType outputType;
+        public VisualRust.Shared.BuildOutputType OutputType { get { return outputType; }  set { outputType = value; } }
 
         public bool IsEqual(Application obj)
         {
             return true
+                && EqualityComparer<System.String>.Default.Equals(CrateName, obj.CrateName)
+                && EqualityComparer<VisualRust.Shared.BuildOutputType>.Default.Equals(OutputType, obj.OutputType)
             ;
         }
 
@@ -17,17 +23,23 @@ namespace VisualRust.Project.Configuration
         {
             return new Application
             {
+                CrateName = this.CrateName,
+                OutputType = this.OutputType,
             };
         }
 
         public static Application LoadFrom(CommonProjectNode proj)
         {
             var x = new Application();
+            Utils.FromString(proj.GetUnevaluatedProperty("CrateName"), out x.crateName);
+            x.OutputType = OutputTypeFromString(proj.GetUnevaluatedProperty("PlatformTarget"));
             return x;
         }
 
         public void SaveTo(CommonProjectNode proj)
         {
+            proj.SetProjectProperty("CrateName", CrateName.ToString());
+            proj.SetProjectProperty("PlatformTarget", OutputTypeToString(OutputType));
         }
     }
 }

--- a/VisualRust.Project/Configuration/Application.cs
+++ b/VisualRust.Project/Configuration/Application.cs
@@ -54,14 +54,14 @@ namespace VisualRust.Project.Configuration
         public static Application LoadFrom(CommonProjectNode proj)
         {
             var x = new Application();
-            x.OutputType = OutputTypeFromString(proj.GetUnevaluatedProperty("CrateType"));
+            x.OutputType = OutputTypeFromString(proj.GetUnevaluatedProperty("OutputType"));
             Utils.FromString(proj.GetUnevaluatedProperty("CrateName"), out x.crateName);
             return x;
         }
 
         public void SaveTo(CommonProjectNode proj)
         {
-            proj.SetProjectProperty("CrateType", OutputTypeToString(OutputType));
+            proj.SetProjectProperty("OutputType", OutputTypeToString(OutputType));
             proj.SetProjectProperty("CrateName", CrateName.ToString());
         }
     }

--- a/VisualRust.Project/Configuration/Application.cs
+++ b/VisualRust.Project/Configuration/Application.cs
@@ -54,14 +54,14 @@ namespace VisualRust.Project.Configuration
         public static Application LoadFrom(CommonProjectNode proj)
         {
             var x = new Application();
-            x.OutputType = OutputTypeFromString(proj.GetUnevaluatedProperty("PlatformTarget"));
+            x.OutputType = OutputTypeFromString(proj.GetUnevaluatedProperty("CrateType"));
             Utils.FromString(proj.GetUnevaluatedProperty("CrateName"), out x.crateName);
             return x;
         }
 
         public void SaveTo(CommonProjectNode proj)
         {
-            proj.SetProjectProperty("PlatformTarget", OutputTypeToString(OutputType));
+            proj.SetProjectProperty("CrateType", OutputTypeToString(OutputType));
             proj.SetProjectProperty("CrateName", CrateName.ToString());
         }
     }

--- a/VisualRust.Project/Configuration/Application.cs
+++ b/VisualRust.Project/Configuration/Application.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudioTools.Project;
+
+namespace VisualRust.Project.Configuration
+{
+    partial class Application
+    {
+
+        public bool IsEqual(Application obj)
+        {
+            return true
+            ;
+        }
+
+        public Application Clone()
+        {
+            return new Application
+            {
+            };
+        }
+
+        public static Application LoadFrom(CommonProjectNode proj)
+        {
+            var x = new Application();
+            return x;
+        }
+
+        public void SaveTo(CommonProjectNode proj)
+        {
+        }
+    }
+}
+

--- a/VisualRust.Project/Configuration/Application.tt
+++ b/VisualRust.Project/Configuration/Application.tt
@@ -5,7 +5,7 @@
     bool ConfigurationDependent = false;
     Field[] Fields = new Field[]
     {
-        new Field { Name = "OutputType", Type = "VisualRust.Shared.BuildOutputType", Key = "PlatformTarget", Normalize = true },
+        new Field { Name = "OutputType", Type = "VisualRust.Shared.BuildOutputType", Key = "CrateType", Normalize = true },
         new Field { Name = "CrateName", Type = typeof(string), Key = "CrateName" },
     };
 #>

--- a/VisualRust.Project/Configuration/Application.tt
+++ b/VisualRust.Project/Configuration/Application.tt
@@ -4,5 +4,7 @@
 <#+
     Field[] Fields = new Field[]
     {
+        new Field { Name = "CrateName", Type = typeof(string), Key = "CrateName" },
+        new Field { Name = "OutputType", Type = "VisualRust.Shared.BuildOutputType", Key = "PlatformTarget", Normalize = true },
     };
 #>

--- a/VisualRust.Project/Configuration/Application.tt
+++ b/VisualRust.Project/Configuration/Application.tt
@@ -1,7 +1,8 @@
 ﻿<#@ template debug="false" hostspecific="true" language="C#" #>
 <#@ output extension=".cs" #>
-<#@ include file="ControllerTemplate.ttinclude" #>
+<#@ include file="ConfigurationTemplate.ttinclude" #>
 <#+
+    bool ConfigurationDependent = false;
     Field[] Fields = new Field[]
     {
         new Field { Name = "OutputType", Type = "VisualRust.Shared.BuildOutputType", Key = "PlatformTarget", Normalize = true },

--- a/VisualRust.Project/Configuration/Application.tt
+++ b/VisualRust.Project/Configuration/Application.tt
@@ -4,7 +4,7 @@
 <#+
     Field[] Fields = new Field[]
     {
-        new Field { Name = "CrateName", Type = typeof(string), Key = "CrateName" },
         new Field { Name = "OutputType", Type = "VisualRust.Shared.BuildOutputType", Key = "PlatformTarget", Normalize = true },
+        new Field { Name = "CrateName", Type = typeof(string), Key = "CrateName" },
     };
 #>

--- a/VisualRust.Project/Configuration/Application.tt
+++ b/VisualRust.Project/Configuration/Application.tt
@@ -5,7 +5,7 @@
     bool ConfigurationDependent = false;
     Field[] Fields = new Field[]
     {
-        new Field { Name = "OutputType", Type = "VisualRust.Shared.BuildOutputType", Key = "CrateType", Normalize = true },
+        new Field { Name = "OutputType", Type = "VisualRust.Shared.BuildOutputType", Key = "OutputType", Normalize = true },
         new Field { Name = "CrateName", Type = typeof(string), Key = "CrateName" },
     };
 #>

--- a/VisualRust.Project/Configuration/Application.tt
+++ b/VisualRust.Project/Configuration/Application.tt
@@ -1,0 +1,8 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ include file="ControllerTemplate.ttinclude" #>
+<#+
+    Field[] Fields = new Field[]
+    {
+    };
+#>

--- a/VisualRust.Project/Configuration/Build.Custom.cs
+++ b/VisualRust.Project/Configuration/Build.Custom.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.VisualStudioTools.Project;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Project.Configuration
+{
+    partial class Build
+    {
+        void SaveUseDefaultTarget()
+        {
+
+        }
+
+        static bool LoadUseDefaultTarget(CommonProjectNode node)
+        {
+            return true;
+        }
+    }
+}

--- a/VisualRust.Project/Configuration/Build.Custom.cs
+++ b/VisualRust.Project/Configuration/Build.Custom.cs
@@ -11,14 +11,16 @@ namespace VisualRust.Project.Configuration
 {
     partial class Build
     {
-        private static OptimizationLevel OptimizationLevelFromString(string p)
+        private static OptimizationLevel? OptimizationLevelFromString(string p)
         {
             return OptimizationLevelExtension.Parse(p);
         }
 
-        private string OptimizationLevelToString(OptimizationLevel OptimizationLevel)
+        private string OptimizationLevelToString(OptimizationLevel? OptimizationLevel)
         {
-            return optimizationLevel.ToBuildString();
+            if(!optimizationLevel.HasValue)
+                return null;
+            return optimizationLevel.Value.ToBuildString();
         }
 
         private static string PlatformTargetFromString(string p)

--- a/VisualRust.Project/Configuration/Build.Custom.cs
+++ b/VisualRust.Project/Configuration/Build.Custom.cs
@@ -1,22 +1,37 @@
 ﻿using Microsoft.VisualStudioTools.Project;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using VisualRust.Shared;
 
 namespace VisualRust.Project.Configuration
 {
     partial class Build
     {
-        void SaveUseDefaultTarget()
+        private static OptimizationLevel OptimizationLevelFromString(string p)
         {
-
+            return OptimizationLevelExtension.Parse(p);
         }
 
-        static bool LoadUseDefaultTarget(CommonProjectNode node)
+        private string OptimizationLevelToString(OptimizationLevel OptimizationLevel)
         {
-            return true;
+            return optimizationLevel.ToBuildString();
         }
+
+        private static string PlatformTargetFromString(string p)
+        {
+            if(String.IsNullOrEmpty(p))
+                return Shared.Environment.DefaultTarget;
+            return p;
+        }
+
+        private string PlatformTargetToString(string target)
+        {
+            return target;
+        }
+
     }
 }

--- a/VisualRust.Project/Configuration/Build.cs
+++ b/VisualRust.Project/Configuration/Build.cs
@@ -6,22 +6,63 @@ namespace VisualRust.Project.Configuration
 {
     partial class Build
     {
-        private System.String platformTarget;
-        public System.String PlatformTarget { get { return platformTarget; }  set { platformTarget = value; } }
-        private VisualRust.Shared.OptimizationLevel optimizationLevel;
-        public VisualRust.Shared.OptimizationLevel OptimizationLevel { get { return optimizationLevel; }  set { optimizationLevel = value; } }
+        public event EventHandler Changed;
         private System.Boolean lTO;
-        public System.Boolean LTO { get { return lTO; }  set { lTO = value; } }
-        private System.Boolean emitDebug;
-        public System.Boolean EmitDebug { get { return emitDebug; }  set { emitDebug = value; } }
-
-        public bool IsEqual(Build obj)
+        public System.Boolean LTO
         {
-            return true
-                && EqualityComparer<System.String>.Default.Equals(PlatformTarget, obj.PlatformTarget)
-                && EqualityComparer<VisualRust.Shared.OptimizationLevel>.Default.Equals(OptimizationLevel, obj.OptimizationLevel)
-                && EqualityComparer<System.Boolean>.Default.Equals(LTO, obj.LTO)
-                && EqualityComparer<System.Boolean>.Default.Equals(EmitDebug, obj.EmitDebug)
+            get { return lTO; }
+            set
+            {
+                lTO = value;
+                var temp = Changed;
+                if(temp != null)
+                    temp(this, new EventArgs());
+            }
+        }
+        private System.Boolean emitDebug;
+        public System.Boolean EmitDebug
+        {
+            get { return emitDebug; }
+            set
+            {
+                emitDebug = value;
+                var temp = Changed;
+                if(temp != null)
+                    temp(this, new EventArgs());
+            }
+        }
+        private VisualRust.Shared.OptimizationLevel optimizationLevel;
+        public VisualRust.Shared.OptimizationLevel OptimizationLevel
+        {
+            get { return optimizationLevel; }
+            set
+            {
+                optimizationLevel = value;
+                var temp = Changed;
+                if(temp != null)
+                    temp(this, new EventArgs());
+            }
+        }
+        private System.String platformTarget;
+        public System.String PlatformTarget
+        {
+            get { return platformTarget; }
+            set
+            {
+                platformTarget = value;
+                var temp = Changed;
+                if(temp != null)
+                    temp(this, new EventArgs());
+            }
+        }
+
+        public bool HasChangedFrom(Build obj)
+        {
+            return false
+            || (!EqualityComparer<System.Boolean>.Default.Equals(LTO, obj.LTO))
+            || (!EqualityComparer<System.Boolean>.Default.Equals(EmitDebug, obj.EmitDebug))
+            || (!EqualityComparer<VisualRust.Shared.OptimizationLevel>.Default.Equals(OptimizationLevel, obj.OptimizationLevel))
+            || (!EqualityComparer<System.String>.Default.Equals(PlatformTarget, obj.PlatformTarget))
             ;
         }
 
@@ -29,29 +70,29 @@ namespace VisualRust.Project.Configuration
         {
             return new Build
             {
-                PlatformTarget = this.PlatformTarget,
-                OptimizationLevel = this.OptimizationLevel,
                 LTO = this.LTO,
                 EmitDebug = this.EmitDebug,
+                OptimizationLevel = this.OptimizationLevel,
+                PlatformTarget = this.PlatformTarget,
             };
         }
 
         public static Build LoadFrom(CommonProjectNode proj)
         {
             var x = new Build();
-            x.PlatformTarget = PlatformTargetFromString(proj.GetUnevaluatedProperty("PlatformTarget"));
-            x.OptimizationLevel = OptimizationLevelFromString(proj.GetUnevaluatedProperty("OptimizationLevel"));
             Utils.FromString(proj.GetUnevaluatedProperty("LinkTimeOptimization"), out x.lTO);
             Utils.FromString(proj.GetUnevaluatedProperty("DebugSymbols"), out x.emitDebug);
+            x.OptimizationLevel = OptimizationLevelFromString(proj.GetUnevaluatedProperty("OptimizationLevel"));
+            x.PlatformTarget = PlatformTargetFromString(proj.GetUnevaluatedProperty("PlatformTarget"));
             return x;
         }
 
         public void SaveTo(CommonProjectNode proj)
         {
-            proj.SetProjectProperty("PlatformTarget", PlatformTargetToString(PlatformTarget));
-            proj.SetProjectProperty("OptimizationLevel", OptimizationLevelToString(OptimizationLevel));
             proj.SetProjectProperty("LinkTimeOptimization", LTO.ToString());
             proj.SetProjectProperty("DebugSymbols", EmitDebug.ToString());
+            proj.SetProjectProperty("OptimizationLevel", OptimizationLevelToString(OptimizationLevel));
+            proj.SetProjectProperty("PlatformTarget", PlatformTargetToString(PlatformTarget));
         }
     }
 }

--- a/VisualRust.Project/Configuration/Build.cs
+++ b/VisualRust.Project/Configuration/Build.cs
@@ -6,16 +6,22 @@ namespace VisualRust.Project.Configuration
 {
     partial class Build
     {
-        private System.Boolean useDefaultTarget;
-        public System.Boolean UseDefaultTarget { get { return useDefaultTarget; }  set { useDefaultTarget = value; } }
         private System.String platformTarget;
         public System.String PlatformTarget { get { return platformTarget; }  set { platformTarget = value; } }
+        private VisualRust.Shared.OptimizationLevel optimizationLevel;
+        public VisualRust.Shared.OptimizationLevel OptimizationLevel { get { return optimizationLevel; }  set { optimizationLevel = value; } }
+        private System.Boolean lTO;
+        public System.Boolean LTO { get { return lTO; }  set { lTO = value; } }
+        private System.Boolean emitDebug;
+        public System.Boolean EmitDebug { get { return emitDebug; }  set { emitDebug = value; } }
 
         public bool IsEqual(Build obj)
         {
             return true
-                && EqualityComparer<System.Boolean>.Default.Equals(UseDefaultTarget, obj.UseDefaultTarget)
                 && EqualityComparer<System.String>.Default.Equals(PlatformTarget, obj.PlatformTarget)
+                && EqualityComparer<VisualRust.Shared.OptimizationLevel>.Default.Equals(OptimizationLevel, obj.OptimizationLevel)
+                && EqualityComparer<System.Boolean>.Default.Equals(LTO, obj.LTO)
+                && EqualityComparer<System.Boolean>.Default.Equals(EmitDebug, obj.EmitDebug)
             ;
         }
 
@@ -23,23 +29,29 @@ namespace VisualRust.Project.Configuration
         {
             return new Build
             {
-                UseDefaultTarget = this.UseDefaultTarget,
                 PlatformTarget = this.PlatformTarget,
+                OptimizationLevel = this.OptimizationLevel,
+                LTO = this.LTO,
+                EmitDebug = this.EmitDebug,
             };
         }
 
         public static Build LoadFrom(CommonProjectNode proj)
         {
             var x = new Build();
-            x.UseDefaultTarget = LoadUseDefaultTarget(proj);
-            Utils.FromString(proj.GetUnevaluatedProperty("PlatformTarget"), out x.platformTarget);
+            x.PlatformTarget = PlatformTargetFromString(proj.GetUnevaluatedProperty("PlatformTarget"));
+            x.OptimizationLevel = OptimizationLevelFromString(proj.GetUnevaluatedProperty("OptimizationLevel"));
+            Utils.FromString(proj.GetUnevaluatedProperty("LinkTimeOptimization"), out x.lTO);
+            Utils.FromString(proj.GetUnevaluatedProperty("DebugSymbols"), out x.emitDebug);
             return x;
         }
 
         public void SaveTo(CommonProjectNode proj)
         {
-            SaveUseDefaultTarget();
-            proj.SetProjectProperty("PlatformTarget", PlatformTarget.ToString());
+            proj.SetProjectProperty("PlatformTarget", PlatformTargetToString(PlatformTarget));
+            proj.SetProjectProperty("OptimizationLevel", OptimizationLevelToString(OptimizationLevel));
+            proj.SetProjectProperty("LinkTimeOptimization", LTO.ToString());
+            proj.SetProjectProperty("DebugSymbols", EmitDebug.ToString());
         }
     }
 }

--- a/VisualRust.Project/Configuration/Build.cs
+++ b/VisualRust.Project/Configuration/Build.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudioTools.Project;
+
+namespace VisualRust.Project.Configuration
+{
+    partial class Build
+    {
+        private System.Boolean useDefaultTarget;
+        public System.Boolean UseDefaultTarget { get { return useDefaultTarget; }  set { useDefaultTarget = value; } }
+        private System.String platformTarget;
+        public System.String PlatformTarget { get { return platformTarget; }  set { platformTarget = value; } }
+
+        public bool IsEqual(Build obj)
+        {
+            return true
+                && EqualityComparer<System.Boolean>.Default.Equals(UseDefaultTarget, obj.UseDefaultTarget)
+                && EqualityComparer<System.String>.Default.Equals(PlatformTarget, obj.PlatformTarget)
+            ;
+        }
+
+        public Build Clone()
+        {
+            return new Build
+            {
+                UseDefaultTarget = this.UseDefaultTarget,
+                PlatformTarget = this.PlatformTarget,
+            };
+        }
+
+        public static Build LoadFrom(CommonProjectNode proj)
+        {
+            var x = new Build();
+            x.UseDefaultTarget = LoadUseDefaultTarget(proj);
+            Utils.FromString(proj.GetUnevaluatedProperty("PlatformTarget"), out x.platformTarget);
+            return x;
+        }
+
+        public void SaveTo(CommonProjectNode proj)
+        {
+            SaveUseDefaultTarget();
+            proj.SetProjectProperty("PlatformTarget", PlatformTarget.ToString());
+        }
+    }
+}
+

--- a/VisualRust.Project/Configuration/Build.tt
+++ b/VisualRust.Project/Configuration/Build.tt
@@ -4,9 +4,9 @@
 <#+
     Field[] Fields = new Field[]
     {
-        new Field { Name = "PlatformTarget", Type = typeof(string), Key= "PlatformTarget", Normalize = true },
-        new Field { Name = "OptimizationLevel", Type = "VisualRust.Shared.OptimizationLevel", Key= "OptimizationLevel", Normalize = true },
         new Field { Name = "LTO", Type = typeof(bool), Key= "LinkTimeOptimization" },
         new Field { Name = "EmitDebug", Type = typeof(bool), Key= "DebugSymbols" },
+        new Field { Name = "OptimizationLevel", Type = "VisualRust.Shared.OptimizationLevel", Key= "OptimizationLevel", Normalize = true },
+        new Field { Name = "PlatformTarget", Type = typeof(string), Key= "PlatformTarget", Normalize = true },
     };
 #>

--- a/VisualRust.Project/Configuration/Build.tt
+++ b/VisualRust.Project/Configuration/Build.tt
@@ -1,12 +1,13 @@
 ﻿<#@ template debug="false" hostspecific="true" language="C#" #>
 <#@ output extension=".cs" #>
-<#@ include file="ControllerTemplate.ttinclude" #>
+<#@ include file="ConfigurationTemplate.ttinclude" #>
 <#+
+    bool ConfigurationDependent = true;
     Field[] Fields = new Field[]
     {
-        new Field { Name = "LTO", Type = typeof(bool), Key= "LinkTimeOptimization" },
-        new Field { Name = "EmitDebug", Type = typeof(bool), Key= "DebugSymbols" },
-        new Field { Name = "OptimizationLevel", Type = "VisualRust.Shared.OptimizationLevel", Key= "OptimizationLevel", Normalize = true },
+        new Field { Name = "LTO", Type = "bool?", Key= "LinkTimeOptimization" },
+        new Field { Name = "EmitDebug", Type = "bool?", Key= "DebugSymbols" },
+        new Field { Name = "OptimizationLevel", Type = "VisualRust.Shared.OptimizationLevel?", Key= "OptimizationLevel", Normalize = true },
         new Field { Name = "PlatformTarget", Type = typeof(string), Key= "PlatformTarget", Normalize = true },
     };
 #>

--- a/VisualRust.Project/Configuration/Build.tt
+++ b/VisualRust.Project/Configuration/Build.tt
@@ -1,0 +1,10 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ include file="ControllerTemplate.ttinclude" #>
+<#+
+    Field[] Fields = new Field[]
+    {
+        new Field { Name = "UseDefaultTarget", Type = typeof(bool) },
+        new Field { Name = "PlatformTarget", Type = typeof(string), Key= "PlatformTarget"  },
+    };
+#>

--- a/VisualRust.Project/Configuration/Build.tt
+++ b/VisualRust.Project/Configuration/Build.tt
@@ -4,7 +4,9 @@
 <#+
     Field[] Fields = new Field[]
     {
-        new Field { Name = "UseDefaultTarget", Type = typeof(bool) },
-        new Field { Name = "PlatformTarget", Type = typeof(string), Key= "PlatformTarget"  },
+        new Field { Name = "PlatformTarget", Type = typeof(string), Key= "PlatformTarget", Normalize = true },
+        new Field { Name = "OptimizationLevel", Type = "VisualRust.Shared.OptimizationLevel", Key= "OptimizationLevel", Normalize = true },
+        new Field { Name = "LTO", Type = typeof(bool), Key= "LinkTimeOptimization" },
+        new Field { Name = "EmitDebug", Type = typeof(bool), Key= "DebugSymbols" },
     };
 #>

--- a/VisualRust.Project/Configuration/ConfigurationTemplate.ttinclude
+++ b/VisualRust.Project/Configuration/ConfigurationTemplate.ttinclude
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using Microsoft.VisualStudioTools.Project;
 
@@ -7,10 +8,7 @@ namespace VisualRust.Project.Configuration
     partial class <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#>
     {
         public event EventHandler Changed;
-<#
-        foreach(var f in Fields)
-        {
-#>
+<# foreach(var f in Fields) { #>
         private <#= f.Type #> <#= f.NameLower #>;
         public <#= f.Type #> <#= f.NameUpper #>
         {
@@ -22,22 +20,15 @@ namespace VisualRust.Project.Configuration
                 if(temp != null)
                     temp(this, new EventArgs());
             }
-        }
-<#
-        }
-#>
+        } 
+<# } #>
 
         public bool HasChangedFrom(<#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#> obj)
         {
             return false
-<#
-            foreach(var f in Fields)
-            {
-#>
+<# foreach(var f in Fields) { #>
             || (!EqualityComparer<<#= f.Type #>>.Default.Equals(<#= f.NameUpper #>, obj.<#= f.NameUpper #>))
-<#
-            }
-#>
+<# } #>
             ;
         }
 
@@ -45,76 +36,81 @@ namespace VisualRust.Project.Configuration
         {
             return new <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#>
             {
-<#
-                foreach(var f in Fields)
-                {
-#>
+<# foreach(var f in Fields) { #>
                 <#= f.NameUpper #> = this.<#= f.NameUpper #>,
-<#
-                }
-#>
+<# } #>
             };
         }
 
+<# if(ConfigurationDependent) { /* Aggregate load */ #>
+        public static <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#> LoadFrom(ProjectConfig[] configs)
+        {
+            return configs.Select(LoadFromForConfig).Aggregate((prev, cur) =>
+            {
+<# foreach(var f in Fields) { #>
+                if(prev.<#= f.NameUpper #> != null && !EqualityComparer<<#= f.Type #>>.Default.Equals(prev.<#= f.NameUpper #>, cur.<#= f.NameUpper #>))
+                    prev.<#= f.NameUpper #> = null;
+<# } #>
+                return prev;
+            });
+        }
+<# } #>
+
+<# if(ConfigurationDependent) { #>
+        private static <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#> LoadFromForConfig(ProjectConfig cfg)
+        {
+            var x = new <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#>();
+<# foreach(var f in Fields) { 
+    if(f.Normalize) { #>
+            x.<#= f.NameUpper #> = <#= f.NameUpper #>FromString(cfg.GetConfigurationProperty("<#= f.Key #>", false));
+<#  } else { #>
+            Utils.FromString(cfg.GetConfigurationProperty("<#= f.Key #>", false), out x.<#= f.NameLower #>);
+<#  }
+} #>
+            return x;
+        }
+<# } else { #>
         public static <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#> LoadFrom(CommonProjectNode proj)
         {
             var x = new <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#>();
-<#
-            foreach(var f in Fields)
-            {
-                if(f.Key != null)
-                {
-                    if(f.Normalize)
-                    {
-#>
+<# foreach(var f in Fields) { 
+    if(f.Normalize) { #>
             x.<#= f.NameUpper #> = <#= f.NameUpper #>FromString(proj.GetUnevaluatedProperty("<#= f.Key #>"));
-<#
-                    }
-                    else
-                    {
-#>
+<#  } else { #>
             Utils.FromString(proj.GetUnevaluatedProperty("<#= f.Key #>"), out x.<#= f.NameLower #>);
-<#
-                    }
-                }
-                else
-                {
-#>
-            x.<#= f.NameUpper #> = Load<#= f.NameUpper #>(proj);
-<#              }
-            }
-#>
+<#  }
+} #>
             return x;
         }
+<# } #>
 
+<# if(ConfigurationDependent) { #>
+        public void SaveTo(ProjectConfig[] configs)
+        {
+            foreach(ProjectConfig cfg in configs)
+            {
+<# foreach(Field f in Fields) { #>
+                if(<#= f.NameUpper #> != null)
+<#  if(f.Normalize) { #>
+                    cfg.SetConfigurationProperty("<#= f.Key #>", <#= f.NameUpper #>ToString(<#= f.NameUpper #>));
+<#  } else { #>
+                    cfg.SetConfigurationProperty("<#= f.Key #>", <#= f.NameUpper #>.ToString());
+<#  }
+} #>
+            }
+        }
+<# } else { #>
         public void SaveTo(CommonProjectNode proj)
         {
-<#
-            foreach(var f in Fields)
-            {
-                if(f.Key != null)
-                {
-                    if(f.Normalize)
-                    {
-#>
+<# foreach(Field f in Fields) {
+    if(f.Normalize) { #>
             proj.SetProjectProperty("<#= f.Key #>", <#= f.NameUpper #>ToString(<#= f.NameUpper #>));
-<#
-                    }
-                    else
-                    {
-#>
+<#  } else { #>
             proj.SetProjectProperty("<#= f.Key #>", <#= f.NameUpper #>.ToString());
-<#
-                    }
-                }
-                else
-                {
-#>
-            Save<#= f.NameUpper #>();
-<#              }
-            }
-#>
+<#  }
+} #>
         }
+<# } #>
     }
 }
 <#+

--- a/VisualRust.Project/Configuration/ControllerTemplate.ttinclude
+++ b/VisualRust.Project/Configuration/ControllerTemplate.ttinclude
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudioTools.Project;
+
+namespace VisualRust.Project.Configuration
+{
+    partial class <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#>
+    {
+<#
+        foreach(var f in Fields)
+        {
+#>
+        private <#= f.Type.FullName #> <#= f.NameLower #>;
+        public <#= f.Type.FullName #> <#= f.NameUpper #> { get { return <#= f.NameLower #>; }  set { <#= f.NameLower #> = value; } }
+<#
+        }
+#>
+
+        public bool IsEqual(<#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#> obj)
+        {
+            return true
+<#
+            foreach(var f in Fields)
+            {
+#>
+                && EqualityComparer<<#= f.Type.FullName #>>.Default.Equals(<#= f.NameUpper #>, obj.<#= f.NameUpper #>)
+<#
+            }
+#>
+            ;
+        }
+
+        public <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#> Clone()
+        {
+            return new <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#>
+            {
+<#
+                foreach(var f in Fields)
+                {
+#>
+                <#= f.NameUpper #> = this.<#= f.NameUpper #>,
+<#
+                }
+#>
+            };
+        }
+
+        public static <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#> LoadFrom(CommonProjectNode proj)
+        {
+            var x = new <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#>();
+<#
+            foreach(var f in Fields)
+            {
+                if(f.Key != null)
+                {
+#>
+            Utils.FromString(proj.GetUnevaluatedProperty("<#= f.Key #>"), out x.<#= f.NameLower #>);
+<#
+                }
+                else
+                {
+#>
+            x.<#= f.NameUpper #> = Load<#= f.NameUpper #>(proj);
+<#              }
+            }
+#>
+            return x;
+        }
+
+        public void SaveTo(CommonProjectNode proj)
+        {
+<#
+            foreach(var f in Fields)
+            {
+                if(f.Key != null)
+                {
+#>
+            proj.SetProjectProperty("<#= f.Key #>", <#= f.NameUpper #>.ToString());
+<#
+                }
+                else
+                {
+#>
+            Save<#= f.NameUpper #>();
+<#              }
+            }
+#>
+        }
+    }
+}
+<#+
+    class Field
+    {
+        public string Name { get; set; }
+        public Type Type { get; set; }
+        public string Key {  get; set; }
+        public string NameUpper { get { return char.ToUpper(Name[0]) + Name.Substring(1); } }
+        public string NameLower { get { return char.ToLower(Name[0]) + Name.Substring(1); } }
+    }
+#>

--- a/VisualRust.Project/Configuration/ControllerTemplate.ttinclude
+++ b/VisualRust.Project/Configuration/ControllerTemplate.ttinclude
@@ -6,24 +6,35 @@ namespace VisualRust.Project.Configuration
 {
     partial class <#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#>
     {
+        public event EventHandler Changed;
 <#
         foreach(var f in Fields)
         {
 #>
         private <#= f.Type #> <#= f.NameLower #>;
-        public <#= f.Type #> <#= f.NameUpper #> { get { return <#= f.NameLower #>; }  set { <#= f.NameLower #> = value; } }
+        public <#= f.Type #> <#= f.NameUpper #>
+        {
+            get { return <#= f.NameLower #>; }
+            set
+            {
+                <#= f.NameLower #> = value;
+                var temp = Changed;
+                if(temp != null)
+                    temp(this, new EventArgs());
+            }
+        }
 <#
         }
 #>
 
-        public bool IsEqual(<#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#> obj)
+        public bool HasChangedFrom(<#= System.IO.Path.GetFileNameWithoutExtension(Host.TemplateFile)#> obj)
         {
-            return true
+            return false
 <#
             foreach(var f in Fields)
             {
 #>
-                && EqualityComparer<<#= f.Type #>>.Default.Equals(<#= f.NameUpper #>, obj.<#= f.NameUpper #>)
+            || (!EqualityComparer<<#= f.Type #>>.Default.Equals(<#= f.NameUpper #>, obj.<#= f.NameUpper #>))
 <#
             }
 #>
@@ -111,7 +122,7 @@ namespace VisualRust.Project.Configuration
     {
         public string Name { get; set; }
         public object Type { get; set; }
-        public string Key {  get; set; }
+        public string Key { get; set; }
         public bool Normalize { get; set; }
         public string NameUpper { get { return char.ToUpper(Name[0]) + Name.Substring(1); } }
         public string NameLower { get { return char.ToLower(Name[0]) + Name.Substring(1); } }

--- a/VisualRust.Project/Configuration/ControllerTemplate.ttinclude
+++ b/VisualRust.Project/Configuration/ControllerTemplate.ttinclude
@@ -10,8 +10,8 @@ namespace VisualRust.Project.Configuration
         foreach(var f in Fields)
         {
 #>
-        private <#= f.Type.FullName #> <#= f.NameLower #>;
-        public <#= f.Type.FullName #> <#= f.NameUpper #> { get { return <#= f.NameLower #>; }  set { <#= f.NameLower #> = value; } }
+        private <#= f.Type #> <#= f.NameLower #>;
+        public <#= f.Type #> <#= f.NameUpper #> { get { return <#= f.NameLower #>; }  set { <#= f.NameLower #> = value; } }
 <#
         }
 #>
@@ -23,7 +23,7 @@ namespace VisualRust.Project.Configuration
             foreach(var f in Fields)
             {
 #>
-                && EqualityComparer<<#= f.Type.FullName #>>.Default.Equals(<#= f.NameUpper #>, obj.<#= f.NameUpper #>)
+                && EqualityComparer<<#= f.Type #>>.Default.Equals(<#= f.NameUpper #>, obj.<#= f.NameUpper #>)
 <#
             }
 #>
@@ -53,9 +53,18 @@ namespace VisualRust.Project.Configuration
             {
                 if(f.Key != null)
                 {
+                    if(f.Normalize)
+                    {
+#>
+            x.<#= f.NameUpper #> = <#= f.NameUpper #>FromString(proj.GetUnevaluatedProperty("<#= f.Key #>"));
+<#
+                    }
+                    else
+                    {
 #>
             Utils.FromString(proj.GetUnevaluatedProperty("<#= f.Key #>"), out x.<#= f.NameLower #>);
 <#
+                    }
                 }
                 else
                 {
@@ -74,9 +83,18 @@ namespace VisualRust.Project.Configuration
             {
                 if(f.Key != null)
                 {
+                    if(f.Normalize)
+                    {
+#>
+            proj.SetProjectProperty("<#= f.Key #>", <#= f.NameUpper #>ToString(<#= f.NameUpper #>));
+<#
+                    }
+                    else
+                    {
 #>
             proj.SetProjectProperty("<#= f.Key #>", <#= f.NameUpper #>.ToString());
 <#
+                    }
                 }
                 else
                 {
@@ -92,8 +110,9 @@ namespace VisualRust.Project.Configuration
     class Field
     {
         public string Name { get; set; }
-        public Type Type { get; set; }
+        public object Type { get; set; }
         public string Key {  get; set; }
+        public bool Normalize { get; set; }
         public string NameUpper { get { return char.ToUpper(Name[0]) + Name.Substring(1); } }
         public string NameLower { get { return char.ToLower(Name[0]) + Name.Substring(1); } }
     }

--- a/VisualRust.Project/Configuration/Utils.cs
+++ b/VisualRust.Project/Configuration/Utils.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Project.Configuration
+{
+    static class Utils
+    {
+        public static void FromString(string text, out string val)
+        {
+            val = text;
+        }
+
+        public static void FromString(string text, out bool val)
+        {
+            val = bool.TryParse(text, out val) && val;
+        }
+    }
+}

--- a/VisualRust.Project/Configuration/Utils.cs
+++ b/VisualRust.Project/Configuration/Utils.cs
@@ -17,5 +17,12 @@ namespace VisualRust.Project.Configuration
         {
             val = bool.TryParse(text, out val) && val;
         }
+
+        public static void FromString(string text, out bool? val)
+        {
+            bool temp;
+            FromString(text, out temp);
+            val = temp;
+        }
     }
 }

--- a/VisualRust.Project/Constants.cs
+++ b/VisualRust.Project/Constants.cs
@@ -9,5 +9,6 @@ namespace VisualRust.Project
     public static class Constants
     {
         public const string BuildPropertyPage = "10C47C08-3645-42C8-BBCA-BCBAA0129DF5";
+        public const string ApplicationPropertyPage = "7B1CA802-91F7-4EF4-A1C0-83E40BA72429";
     }
 }

--- a/VisualRust.Project/Constants.cs
+++ b/VisualRust.Project/Constants.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Project
+{
+    public static class Constants
+    {
+        public const string BuildPropertyPage = "10C47C08-3645-42C8-BBCA-BCBAA0129DF5";
+    }
+}

--- a/VisualRust.Project/DefaultRustLauncher.cs
+++ b/VisualRust.Project/DefaultRustLauncher.cs
@@ -7,10 +7,6 @@ using Microsoft.VisualStudioTools.Project;
 
 namespace VisualRust.Project
 {
-    /// <summary>
-    /// Simple realization of project launcher for executable file
-    /// TODO need realize for library
-    /// </summary>
     sealed class DefaultRustLauncher : IProjectLauncher
     {
         private readonly RustProjectNode _project;
@@ -18,12 +14,13 @@ namespace VisualRust.Project
         public DefaultRustLauncher(RustProjectNode project)
         {
             Utilities.ArgumentNotNull("project", project);
-
             _project = project;
         }
 
         public int LaunchProject(bool debug)
         {
+            if(_project.GetProjectProperty("OutputType") != "exe")
+                throw new InvalidOperationException("A project with an Output Type of Library cannot be started directly.");
             var startupFilePath = GetProjectStartupFile();
             return LaunchFile(startupFilePath, debug);
         }
@@ -31,12 +28,10 @@ namespace VisualRust.Project
         private string GetProjectStartupFile()
         {
             var startupFilePath = Path.Combine(_project.GetProjectProperty("TargetDir"), _project.GetProjectProperty("TargetFileName"));
-
-            //var startupFilePath = _project.GetStartupFile();
             
             if (string.IsNullOrEmpty(startupFilePath))
             {
-                throw new ApplicationException("Startup file is not defined in project");
+                throw new ApplicationException("Visual Rust could not resolve path for your executable. Your installation of Visual Rust or .rsproj file might be corrupted.");
             }
 
             return startupFilePath;
@@ -45,24 +40,22 @@ namespace VisualRust.Project
         public int LaunchFile(string file, bool debug)
         {
             StartWithoutDebugger(file);
-
             return VSConstants.S_OK;
         }
 
         private void StartWithoutDebugger(string startupFile)
         {
+            if(!File.Exists(startupFile))
+                _project.Build("Build");
             var processStartInfo = CreateProcessStartInfoNoDebug(startupFile);
             Process.Start(processStartInfo);
         }
 
         private ProcessStartInfo CreateProcessStartInfoNoDebug(string startupFile)
         {
-            // TODO add command line arguments
             var commandLineArgs = string.Empty;
             var startInfo = new ProcessStartInfo(startupFile, commandLineArgs);
-
             startInfo.UseShellExecute = false;
-
             return startInfo;
         }
     }

--- a/VisualRust.Project/Forms/ApplicationPropertyControl.cs
+++ b/VisualRust.Project/Forms/ApplicationPropertyControl.cs
@@ -10,13 +10,16 @@ namespace VisualRust.Project.Forms
 {
     class ApplicationPropertyControl : UserControl
     {
+        private Action<bool> isDirty;
         private Configuration.Application config;
+        private Configuration.Application originalConfig;
         private TableLayoutPanel mainPanel;
         TextBox crateBox;
         ComboBox typeComboBox;
 
-        public ApplicationPropertyControl()
+        public ApplicationPropertyControl(Action<bool> isDirtyAction)
         {
+            isDirty = isDirtyAction;
             this.Font = System.Drawing.SystemFonts.MessageBoxFont;
             mainPanel = new TableLayoutPanel
             {
@@ -44,11 +47,19 @@ namespace VisualRust.Project.Forms
 
         public void LoadSettings(CommonProjectNode node)
         {
-            config = Configuration.Application.LoadFrom(node);
+            originalConfig = Configuration.Application.LoadFrom(node);
+            config = originalConfig.Clone();
             crateBox.Text = config.CrateName;
             crateBox.TextChanged += (src, arg) => config.CrateName = crateBox.Text;
             typeComboBox.SelectedIndex = (int)config.OutputType;
             typeComboBox.SelectedIndexChanged += (src, arg) => config.OutputType = (BuildOutputType)typeComboBox.SelectedIndex;
+            config.Changed += (src, arg) => isDirty(config.HasChangedFrom(originalConfig));
+        }
+
+        public void ApplyConfig(CommonProjectNode node)
+        {
+            config.SaveTo(node);
+            originalConfig = config.Clone();
         }
     }
 }

--- a/VisualRust.Project/Forms/ApplicationPropertyControl.cs
+++ b/VisualRust.Project/Forms/ApplicationPropertyControl.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.VisualStudioTools.Project;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace VisualRust.Project.Forms
+{
+    class ApplicationPropertyControl : UserControl
+    {
+        private Configuration.Application config;
+        private TableLayoutPanel mainPanel;
+
+        public ApplicationPropertyControl()
+        {
+            this.Font = System.Drawing.SystemFonts.MessageBoxFont;
+            mainPanel = new TableLayoutPanel
+            {
+                AutoSize = true,
+                Width = 0,
+                Height = 0,
+                ColumnCount = 1,
+            };
+            mainPanel.Controls.Add(Utils.CreateLabel("Crate name:", Utils.Paddding()));
+            TextBox crateBox = Utils.CreateTextBox("", Utils.Paddding());
+            crateBox.Width = 294;
+            mainPanel.Controls.Add(crateBox);
+            mainPanel.Controls.Add(Utils.CreateLabel("Output type:", Utils.Paddding()));
+            ComboBox typeComboBox = Utils.CreateComboBox(new[] { "Application", "Library"}, Utils.Paddding());
+            typeComboBox.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+            mainPanel.Controls.Add(typeComboBox);
+            this.Controls.Add(mainPanel);
+        }
+
+        public void LoadSettings(CommonProjectNode node)
+        {
+            config = Configuration.Application.LoadFrom(node);
+        }
+    }
+}

--- a/VisualRust.Project/Forms/ApplicationPropertyControl.cs
+++ b/VisualRust.Project/Forms/ApplicationPropertyControl.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using VisualRust.Shared;
 
 namespace VisualRust.Project.Forms
 {
@@ -11,6 +12,8 @@ namespace VisualRust.Project.Forms
     {
         private Configuration.Application config;
         private TableLayoutPanel mainPanel;
+        TextBox crateBox;
+        ComboBox typeComboBox;
 
         public ApplicationPropertyControl()
         {
@@ -23,11 +26,17 @@ namespace VisualRust.Project.Forms
                 ColumnCount = 1,
             };
             mainPanel.Controls.Add(Utils.CreateLabel("Crate name:", Utils.Paddding()));
-            TextBox crateBox = Utils.CreateTextBox("", Utils.Paddding());
+            crateBox = Utils.CreateTextBox("", Utils.Paddding());
             crateBox.Width = 294;
             mainPanel.Controls.Add(crateBox);
             mainPanel.Controls.Add(Utils.CreateLabel("Output type:", Utils.Paddding()));
-            ComboBox typeComboBox = Utils.CreateComboBox(new[] { "Application", "Library"}, Utils.Paddding());
+            typeComboBox = Utils.CreateComboBox(
+                new[]
+                {
+                    BuildOutputType.Application.ToDisplayString(),
+                    BuildOutputType.Library.ToDisplayString()
+                },
+                Utils.Paddding());
             typeComboBox.Anchor = AnchorStyles.Left | AnchorStyles.Right;
             mainPanel.Controls.Add(typeComboBox);
             this.Controls.Add(mainPanel);
@@ -36,6 +45,10 @@ namespace VisualRust.Project.Forms
         public void LoadSettings(CommonProjectNode node)
         {
             config = Configuration.Application.LoadFrom(node);
+            crateBox.Text = config.CrateName;
+            crateBox.TextChanged += (src, arg) => config.CrateName = crateBox.Text;
+            typeComboBox.SelectedIndex = (int)config.OutputType;
+            typeComboBox.SelectedIndexChanged += (src, arg) => config.OutputType = (BuildOutputType)typeComboBox.SelectedIndex;
         }
     }
 }

--- a/VisualRust.Project/Forms/BuildPropertyControl.cs
+++ b/VisualRust.Project/Forms/BuildPropertyControl.cs
@@ -78,24 +78,34 @@ namespace VisualRust.Project.Forms
             return startingRow + 4;
         }
 
-        public void LoadSettings(CommonProjectNode node)
+        public void LoadSettings(ProjectConfig[] configs)
         {
-            originalConfig = Configuration.Build.LoadFrom(node);
+            originalConfig = Configuration.Build.LoadFrom(configs);
             config = originalConfig.Clone();
             customTargetBox.Text = config.PlatformTarget;
             customTargetBox.TextChanged += (src,arg) => config.PlatformTarget = customTargetBox.Text;
-            optimizationBox.SelectedIndex = (int)config.OptimizationLevel;
+            if(config.OptimizationLevel.HasValue)
+                optimizationBox.SelectedIndex = (int)config.OptimizationLevel.Value;
+            else
+                optimizationBox.SelectedItem = null;
             optimizationBox.SelectedIndexChanged += (src,arg) => config.OptimizationLevel = (OptimizationLevel)optimizationBox.SelectedIndex;
-            lto.Checked = config.LTO;
+            lto.CheckState = ToCheckState(config.LTO);
             lto.CheckedChanged += (src,arg) => config.LTO = lto.Checked;
-            emitDebug.Checked = config.EmitDebug;
+            emitDebug.CheckState = ToCheckState(config.EmitDebug);
             emitDebug.CheckedChanged += (src,arg) => config.EmitDebug = emitDebug.Checked;
             config.Changed += (src, arg) => isDirty(config.HasChangedFrom(originalConfig));
         }
 
-        public void ApplyConfig(CommonProjectNode node)
+        private static CheckState ToCheckState(bool? v)
         {
-            config.SaveTo(node);
+            if(!v.HasValue)
+                return CheckState.Indeterminate;
+            return v.Value ? CheckState.Checked : CheckState.Unchecked;
+        }
+
+        public void ApplyConfig(ProjectConfig[] configs)
+        {
+            config.SaveTo(configs);
             originalConfig = config.Clone();
         }
     }

--- a/VisualRust.Project/Forms/BuildPropertyControl.cs
+++ b/VisualRust.Project/Forms/BuildPropertyControl.cs
@@ -11,7 +11,6 @@ namespace VisualRust.Project.Forms
     class BuildPropertyControl : UserControl
     {
         private Configuration.Build buildConfig;
-
         private TableLayoutPanel mainPanel;
 
         public BuildPropertyControl()
@@ -26,20 +25,42 @@ namespace VisualRust.Project.Forms
                 Height = 0,
                 ColumnCount = 2,
             };
-            TableLayoutPanel generalHeader = Utils.CreateHeaderLabel("General");
-            mainPanel.Controls.Add(generalHeader);
-            mainPanel.SetColumnSpan(generalHeader, 2);
+            int generalSectionRows =  AddPlatformTargetSection(mainPanel, 0);
+            AddOutputSection(mainPanel, generalSectionRows);
+            this.Controls.Add(mainPanel);
+        }
+
+        private static int AddPlatformTargetSection(TableLayoutPanel mainPanel, int startingRow)
+        {
+            TableLayoutPanel platformHeader = Utils.CreateHeaderLabel("Platform target");
+            mainPanel.Controls.Add(platformHeader);
+            mainPanel.SetColumnSpan(platformHeader, 2);
             RadioButton defaultPlatform = Utils.CreateRadioButton("Use default platform target", Utils.Paddding().Left().Top());
             mainPanel.Controls.Add(defaultPlatform);
             RadioButton customPlatform = Utils.CreateRadioButton("Use custom target:", Utils.Paddding().Left().Bottom());
             mainPanel.Controls.Add(customPlatform);
-            mainPanel.SetRow(customPlatform, 2);
+            mainPanel.SetRow(customPlatform, startingRow + 2);
             mainPanel.SetColumn(customPlatform, 0);
             TextBox customTargetTextBox = Utils.CreateTextBox("", Utils.Paddding().Bottom());
             mainPanel.Controls.Add(customTargetTextBox);
-            mainPanel.SetRow(customTargetTextBox, 2);
+            mainPanel.SetRow(customTargetTextBox, startingRow + 2);
             mainPanel.SetColumn(customTargetTextBox, 1);
-            this.Controls.Add(mainPanel);
+            return startingRow + 3;
+        }
+
+        private static int AddOutputSection(TableLayoutPanel mainPanel, int startingRow)
+        {
+            TableLayoutPanel outputHeader = Utils.CreateHeaderLabel("Compilation");
+            mainPanel.Controls.Add(outputHeader);
+            mainPanel.SetColumnSpan(outputHeader, 2);
+            mainPanel.Controls.Add(Utils.CreateLabel("Optimization level:", Utils.Paddding().Left().Top()));
+            mainPanel.Controls.Add(Utils.CreateComboBox(new string[] { "none (O0)", "minimal (O1)", "optimized (O2)", "aggresive (O3)" }, Utils.Paddding().Top()));
+            CheckBox lto = Utils.CreateCheckBox("Apply link-time optimization", Utils.Paddding().Left());
+            mainPanel.Controls.Add(lto);
+            mainPanel.SetColumnSpan(lto, 2);
+            mainPanel.Controls.Add(Utils.CreateLabel("Debug information:", Utils.Paddding().Left().Bottom()));
+            mainPanel.Controls.Add(Utils.CreateComboBox(new string[] { "none", "line numbers", "full" }, Utils.Paddding().Bottom()));
+            return startingRow + 4;
         }
 
         public void LoadSettings(CommonProjectNode node)

--- a/VisualRust.Project/Forms/BuildPropertyControl.cs
+++ b/VisualRust.Project/Forms/BuildPropertyControl.cs
@@ -5,16 +5,23 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using VisualRust.Shared;
 
 namespace VisualRust.Project.Forms
 {
     class BuildPropertyControl : UserControl
     {
-        private Configuration.Build buildConfig;
+        private string[] knownTargets;
+        private Configuration.Build config;
         private TableLayoutPanel mainPanel;
+        private ComboBox customTargetBox;
+        private ComboBox optimizationBox;
+        private CheckBox lto;
+        private CheckBox emitDebug;
 
         public BuildPropertyControl()
         {
+            knownTargets = new string[] { Shared.Environment.DefaultTarget }.Union(Shared.Environment.FindInstalledTargets()).ToArray();
             // This looks nonsensical but is required to avoid getting "Microsoft Sans Serif, 8.25pt"
             // http://stackoverflow.com/questions/297701/default-font-for-windows-forms-application
             this.Font = System.Drawing.SystemFonts.MessageBoxFont;
@@ -30,42 +37,55 @@ namespace VisualRust.Project.Forms
             this.Controls.Add(mainPanel);
         }
 
-        private static int AddPlatformTargetSection(TableLayoutPanel mainPanel, int startingRow)
+        private int AddPlatformTargetSection(TableLayoutPanel mainPanel, int startingRow)
         {
-            TableLayoutPanel platformHeader = Utils.CreateHeaderLabel("Platform target");
+            TableLayoutPanel platformHeader = Utils.CreateHeaderLabel("Target");
             mainPanel.Controls.Add(platformHeader);
             mainPanel.SetColumnSpan(platformHeader, 2);
-            RadioButton defaultPlatform = Utils.CreateRadioButton("Use default platform target", Utils.Paddding().Left().Top());
-            mainPanel.Controls.Add(defaultPlatform);
-            RadioButton customPlatform = Utils.CreateRadioButton("Use custom target:", Utils.Paddding().Left().Bottom());
-            mainPanel.Controls.Add(customPlatform);
-            mainPanel.SetRow(customPlatform, startingRow + 2);
-            mainPanel.SetColumn(customPlatform, 0);
-            TextBox customTargetTextBox = Utils.CreateTextBox("", Utils.Paddding().Bottom());
-            mainPanel.Controls.Add(customTargetTextBox);
-            mainPanel.SetRow(customTargetTextBox, startingRow + 2);
-            mainPanel.SetColumn(customTargetTextBox, 1);
-            return startingRow + 3;
+            mainPanel.Controls.Add(Utils.CreateLabel("Platform target:", Utils.Paddding().Left().Top().Bottom()));
+            customTargetBox = Utils.CreateComboBox(knownTargets, Utils.Paddding().Top().Bottom());
+            customTargetBox.DropDownStyle = ComboBoxStyle.DropDown;
+            customTargetBox.Width =(int)(customTargetBox.Width * 1.5);
+            mainPanel.Controls.Add(customTargetBox);
+            return startingRow + 2;
         }
 
-        private static int AddOutputSection(TableLayoutPanel mainPanel, int startingRow)
+        private int AddOutputSection(TableLayoutPanel mainPanel, int startingRow)
         {
             TableLayoutPanel outputHeader = Utils.CreateHeaderLabel("Compilation");
             mainPanel.Controls.Add(outputHeader);
             mainPanel.SetColumnSpan(outputHeader, 2);
             mainPanel.Controls.Add(Utils.CreateLabel("Optimization level:", Utils.Paddding().Left().Top()));
-            mainPanel.Controls.Add(Utils.CreateComboBox(new string[] { "none (O0)", "minimal (O1)", "optimized (O2)", "aggresive (O3)" }, Utils.Paddding().Top()));
-            CheckBox lto = Utils.CreateCheckBox("Apply link-time optimization", Utils.Paddding().Left());
+            optimizationBox = Utils.CreateComboBox(
+                new string[] 
+                {
+                    OptimizationLevel.O0.ToDisplayString(),
+                    OptimizationLevel.O1.ToDisplayString(),
+                    OptimizationLevel.O2.ToDisplayString(),
+                    OptimizationLevel.O3.ToDisplayString(),
+                },
+                Utils.Paddding().Top());
+            mainPanel.Controls.Add(optimizationBox);
+            lto = Utils.CreateCheckBox("Apply link-time optimization", Utils.Paddding().Left());
             mainPanel.Controls.Add(lto);
             mainPanel.SetColumnSpan(lto, 2);
-            mainPanel.Controls.Add(Utils.CreateLabel("Debug information:", Utils.Paddding().Left().Bottom()));
-            mainPanel.Controls.Add(Utils.CreateComboBox(new string[] { "none", "line numbers", "full" }, Utils.Paddding().Bottom()));
+            emitDebug = Utils.CreateCheckBox("Emit debug info", Utils.Paddding().Left().Bottom());
+            mainPanel.Controls.Add(emitDebug);
+            mainPanel.SetColumnSpan(emitDebug, 2);
             return startingRow + 4;
         }
 
         public void LoadSettings(CommonProjectNode node)
         {
-            buildConfig = Configuration.Build.LoadFrom(node);
+            config = Configuration.Build.LoadFrom(node);
+            customTargetBox.Text = config.PlatformTarget;
+            customTargetBox.TextChanged += (src,arg) => config.PlatformTarget = customTargetBox.Text;
+            optimizationBox.SelectedIndex = (int)config.OptimizationLevel;
+            optimizationBox.SelectedIndexChanged += (src,arg) => config.OptimizationLevel = (OptimizationLevel)optimizationBox.SelectedIndex;
+            lto.Checked = config.LTO;
+            lto.CheckedChanged += (src,arg) => config.LTO = lto.Checked;
+            emitDebug.Checked = config.EmitDebug;
+            emitDebug.CheckedChanged += (src,arg) => config.EmitDebug = emitDebug.Checked;
         }
     }
 }

--- a/VisualRust.Project/Forms/BuildPropertyControl.cs
+++ b/VisualRust.Project/Forms/BuildPropertyControl.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.VisualStudioTools.Project;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,5 +10,41 @@ namespace VisualRust.Project.Forms
 {
     class BuildPropertyControl : UserControl
     {
+        private Configuration.Build buildConfig;
+
+        private TableLayoutPanel mainPanel;
+
+        public BuildPropertyControl()
+        {
+            // This looks nonsensical but is required to avoid getting "Microsoft Sans Serif, 8.25pt"
+            // http://stackoverflow.com/questions/297701/default-font-for-windows-forms-application
+            this.Font = System.Drawing.SystemFonts.MessageBoxFont;
+            mainPanel = new TableLayoutPanel
+            {
+                AutoSize = true,
+                Width = 500,
+                Height = 0,
+                ColumnCount = 2,
+            };
+            TableLayoutPanel generalHeader = Utils.CreateHeaderLabel("General");
+            mainPanel.Controls.Add(generalHeader);
+            mainPanel.SetColumnSpan(generalHeader, 2);
+            RadioButton defaultPlatform = Utils.CreateRadioButton("Use default platform target", Utils.Paddding().Left().Top());
+            mainPanel.Controls.Add(defaultPlatform);
+            RadioButton customPlatform = Utils.CreateRadioButton("Use custom target:", Utils.Paddding().Left().Bottom());
+            mainPanel.Controls.Add(customPlatform);
+            mainPanel.SetRow(customPlatform, 2);
+            mainPanel.SetColumn(customPlatform, 0);
+            TextBox customTargetTextBox = Utils.CreateTextBox("", Utils.Paddding().Bottom());
+            mainPanel.Controls.Add(customTargetTextBox);
+            mainPanel.SetRow(customTargetTextBox, 2);
+            mainPanel.SetColumn(customTargetTextBox, 1);
+            this.Controls.Add(mainPanel);
+        }
+
+        public void LoadSettings(CommonProjectNode node)
+        {
+            buildConfig = Configuration.Build.LoadFrom(node);
+        }
     }
 }

--- a/VisualRust.Project/Forms/BuildPropertyControl.cs
+++ b/VisualRust.Project/Forms/BuildPropertyControl.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace VisualRust.Project.Forms
+{
+    class BuildPropertyControl : UserControl
+    {
+    }
+}

--- a/VisualRust.Project/Forms/Utils.cs
+++ b/VisualRust.Project/Forms/Utils.cs
@@ -49,6 +49,41 @@ namespace VisualRust.Project.Forms
             };
         }
 
+        public static Label CreateLabel(string text, Padding margin)
+        {
+            return new Label
+            {
+                Anchor = AnchorStyles.Left,
+                AutoSize = true,
+                Margin = margin,
+                Text = text
+            };
+        }
+
+        public static CheckBox CreateCheckBox(string text, Padding margin)
+        {
+            return new CheckBox
+            {
+                Anchor = AnchorStyles.Left,
+                AutoSize = true,
+                Margin = margin,
+                Text = text
+            };
+        }
+
+        public static ComboBox CreateComboBox(string[] text, Padding margin)
+        {
+            var box = new ComboBox
+            {
+                Anchor = AnchorStyles.Left,
+                AutoSize = true,
+                Margin = margin,
+                DropDownStyle =  ComboBoxStyle.DropDownList
+            };
+            box.Items.AddRange(text);
+            return box;
+        }
+
         public static TextBox CreateTextBox(string text, Padding margin)
         {
             return new TextBox

--- a/VisualRust.Project/Forms/Utils.cs
+++ b/VisualRust.Project/Forms/Utils.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace VisualRust.Project.Forms
+{
+    static class Utils
+    {
+        public static TableLayoutPanel CreateHeaderLabel(string text)
+        {
+            var panel = new TableLayoutPanel
+            {
+                RowCount = 1,
+                ColumnCount = 2,
+                AutoSize = true,
+                Anchor = AnchorStyles.Left | AnchorStyles.Right
+            };
+            panel.Controls.Add(
+                new Label
+                {
+                    Anchor = AnchorStyles.Left,
+                    AutoSize = true,
+                    Margin = new Padding(0, 0, 3, 0),
+                    Text = text
+                });
+            panel.Controls.Add(
+                new Label
+                {
+                    AccessibleRole = System.Windows.Forms.AccessibleRole.Separator,
+                    Anchor = AnchorStyles.Left | AnchorStyles.Right,
+                    BackColor = System.Drawing.SystemColors.ControlDark,
+                    Margin = new Padding(3, 0, 0, 0),
+                    Height = 1
+                });
+            return panel;
+        }
+
+        public static RadioButton CreateRadioButton(string text, Padding margin)
+        {
+            return new RadioButton
+            {
+                AutoSize = true,
+                Anchor = AnchorStyles.Left,
+                Text = text,
+                Margin = margin
+            };
+        }
+
+        public static TextBox CreateTextBox(string text, Padding margin)
+        {
+            return new TextBox
+            {
+                Anchor = AnchorStyles.Left | AnchorStyles.Right,
+                AutoSize = true,
+                Margin = margin
+            };
+        }
+
+        public static Padding Paddding()
+        {
+            return new Padding(3,4,3,4);
+        }
+
+        public static Padding Left(this Padding pad)
+        {
+            pad.Left += 22;
+            return pad;
+        }
+
+        public static Padding Top(this Padding pad)
+        {
+            pad.Top += 10;
+            return pad;
+        }
+
+        public static Padding Bottom(this Padding pad)
+        {
+            pad.Bottom += 10;
+            return pad;
+        }
+    }
+}

--- a/VisualRust.Project/RustConfigProvider.cs
+++ b/VisualRust.Project/RustConfigProvider.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudioTools.Project;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Project
+{
+    class RustConfigProvider : ConfigProvider
+    {
+        private CommonProjectNode project;
+
+        public RustConfigProvider(CommonProjectNode proj) 
+            : base(proj)
+        {
+            this.project = proj;
+        }
+
+        public override int GetPlatformNames(uint celt, string[] names, uint[] actual)
+        {
+            string[] platforms = GetPropertiesConditionedOn(ProjectFileConstants.Platform);
+            if (platforms == null || platforms.Length == 0) {
+                platforms = new string[] { Shared.Environment.DefaultTarget };
+            }
+            return GetPlatforms(celt, names, actual, platforms);
+        }
+
+        public override int GetSupportedPlatformNames(uint celt, string[] names, uint[] actual)
+        {
+            string[] platforms  = 
+                new string[] { Shared.Environment.DefaultTarget }
+                .Union(Shared.Environment.FindInstalledTargets(), StringComparer.OrdinalIgnoreCase ).ToArray();
+            return GetPlatforms(celt, names, actual, platforms);
+        }
+
+        protected override ProjectConfig CreateProjectConfiguration(string configName)
+        {
+            return project.MakeConfiguration(configName);
+        }
+
+        public override int GetCfgProviderProperty(int propid, out object var) {
+            switch ((__VSCFGPROPID)propid) {
+                case __VSCFGPROPID.VSCFGPROPID_SupportsPlatformAdd:
+                case __VSCFGPROPID.VSCFGPROPID_SupportsPlatformDelete:
+                    var = true;
+                    return VSConstants.S_OK;
+            }
+            return base.GetCfgProviderProperty(propid, out var);
+        }
+    }
+}

--- a/VisualRust.Project/RustProjectNode.cs
+++ b/VisualRust.Project/RustProjectNode.cs
@@ -322,6 +322,11 @@ namespace VisualRust.Project
             }
         }
 
+        protected override ConfigProvider CreateConfigProvider()
+        {
+            return new RustConfigProvider(this);
+        }
+
 #region Disable "Add references..."
         protected override ReferenceContainerNode CreateReferenceContainerNode()
         {

--- a/VisualRust.Project/RustProjectNode.cs
+++ b/VisualRust.Project/RustProjectNode.cs
@@ -401,10 +401,17 @@ namespace VisualRust.Project
             get { throw new NotImplementedException(); }
         }
 
-        protected override Guid[] GetConfigurationIndependentPropertyPages() {
+        protected override Guid[] GetConfigurationDependentPropertyPages()
+        {
+            return new[] {
+                new Guid(Constants.BuildPropertyPage)
+            };
+        }
+
+        protected override Guid[] GetConfigurationIndependentPropertyPages()
+        {
             return new[] {
                 new Guid(Constants.ApplicationPropertyPage),
-                new Guid(Constants.BuildPropertyPage)
             };
         }
     }

--- a/VisualRust.Project/RustProjectNode.cs
+++ b/VisualRust.Project/RustProjectNode.cs
@@ -402,7 +402,8 @@ namespace VisualRust.Project
         }
 
         protected override Guid[] GetConfigurationIndependentPropertyPages() {
-            return new[] { 
+            return new[] {
+                new Guid(Constants.ApplicationPropertyPage),
                 new Guid(Constants.BuildPropertyPage)
             };
         }

--- a/VisualRust.Project/RustProjectNode.cs
+++ b/VisualRust.Project/RustProjectNode.cs
@@ -400,5 +400,11 @@ namespace VisualRust.Project
         {
             get { throw new NotImplementedException(); }
         }
+
+        protected override Guid[] GetConfigurationIndependentPropertyPages() {
+            return new[] { 
+                new Guid(Constants.BuildPropertyPage)
+            };
+        }
     }
 }

--- a/VisualRust.Project/VisualRust.Project.csproj
+++ b/VisualRust.Project/VisualRust.Project.csproj
@@ -87,6 +87,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseFileNode.cs" />
+    <Compile Include="Configuration\Application.cs">
+      <DependentUpon>Application.tt</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
     <Compile Include="Configuration\Build.Custom.cs" />
     <Compile Include="Configuration\Utils.cs" />
     <Compile Include="Constants.cs" />
@@ -97,6 +102,9 @@
     </Compile>
     <Compile Include="DefaultRustLauncher.cs" />
     <Compile Include="Forms\BuildPropertyControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Forms\ApplicationPropertyControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="Forms\Utils.cs" />
@@ -163,6 +171,10 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Configuration\Application.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Application.cs</LastGenOutput>
+    </Content>
     <Content Include="Configuration\Build.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Build.cs</LastGenOutput>

--- a/VisualRust.Project/VisualRust.Project.csproj
+++ b/VisualRust.Project/VisualRust.Project.csproj
@@ -166,7 +166,7 @@
     <EmbeddedResource Include="Resources\IconList.bmp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Configuration\ControllerTemplate.ttinclude" />
+    <None Include="Configuration\ConfigurationTemplate.ttinclude" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />

--- a/VisualRust.Project/VisualRust.Project.csproj
+++ b/VisualRust.Project/VisualRust.Project.csproj
@@ -92,6 +92,7 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
     </Compile>
+    <Compile Include="Configuration\Application.Custom.cs" />
     <Compile Include="Configuration\Build.Custom.cs" />
     <Compile Include="Configuration\Utils.cs" />
     <Compile Include="Constants.cs" />

--- a/VisualRust.Project/VisualRust.Project.csproj
+++ b/VisualRust.Project/VisualRust.Project.csproj
@@ -87,11 +87,19 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseFileNode.cs" />
+    <Compile Include="Configuration\Build.Custom.cs" />
+    <Compile Include="Configuration\Utils.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="Configuration\Build.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Build.tt</DependentUpon>
+    </Compile>
     <Compile Include="DefaultRustLauncher.cs" />
     <Compile Include="Forms\BuildPropertyControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Include="Forms\Utils.cs" />
     <Compile Include="IconIndex.cs" />
     <Compile Include="CollectionDifference.cs" />
     <Compile Include="RustConfigProvider.cs" />
@@ -147,6 +155,18 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\IconList.bmp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Configuration\ControllerTemplate.ttinclude" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Configuration\Build.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Build.cs</LastGenOutput>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/VisualRust.Project/VisualRust.Project.csproj
+++ b/VisualRust.Project/VisualRust.Project.csproj
@@ -59,6 +59,7 @@
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Shell.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>False</EmbedInteropTypes>
@@ -86,7 +87,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseFileNode.cs" />
+    <Compile Include="Constants.cs" />
     <Compile Include="DefaultRustLauncher.cs" />
+    <Compile Include="Forms\BuildPropertyControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="IconIndex.cs" />
     <Compile Include="CollectionDifference.cs" />
     <Compile Include="RustConfigProvider.cs" />

--- a/VisualRust.Project/VisualRust.Project.csproj
+++ b/VisualRust.Project/VisualRust.Project.csproj
@@ -89,6 +89,7 @@
     <Compile Include="DefaultRustLauncher.cs" />
     <Compile Include="IconIndex.cs" />
     <Compile Include="CollectionDifference.cs" />
+    <Compile Include="RustConfigProvider.cs" />
     <Compile Include="TrackedFileNode.cs" />
     <Compile Include="FileNodeProperties.cs" />
     <Compile Include="ModuleRemovalResult.cs" />
@@ -120,6 +121,10 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.Project\Microsoft.VisualStudio.Project.csproj">
       <Project>{cacb60a9-1e76-4f92-8831-b134a658c695}</Project>
       <Name>Microsoft.VisualStudio.Project</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\VisualRust.Shared\VisualRust.Shared.csproj">
+      <Project>{b99cc9eb-90f2-4040-9e66-418cc7042153}</Project>
+      <Name>VisualRust.Shared</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/VisualRust.Shared/BuildOutputType.cs
+++ b/VisualRust.Shared/BuildOutputType.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Shared
+{
+    public enum BuildOutputType
+    {
+        Application,
+        Library
+    }
+
+    public static class BuildOutputTypeExtension
+    {
+        public static BuildOutputType Parse(string val)
+        {
+            if(val == null)
+                return BuildOutputType.Application;
+            if(val.Equals("exe", StringComparison.OrdinalIgnoreCase))
+                return BuildOutputType.Application;
+            if(val.Equals("library", StringComparison.OrdinalIgnoreCase))
+                return BuildOutputType.Library;
+            return BuildOutputType.Application;
+        }
+
+        public static string ToBuildString(this BuildOutputType val)
+        {
+            switch(val)
+            {
+                case BuildOutputType.Application:
+                    return "exe";
+                case BuildOutputType.Library:
+                    return "library";
+                default:
+                    throw new ArgumentException("val");
+            }
+        }
+
+        public static string ToDisplayString(this BuildOutputType val)
+        {
+            switch(val)
+            {
+                case BuildOutputType.Application:
+                    return "Application";
+                case BuildOutputType.Library:
+                    return "Library";
+                default:
+                    throw new ArgumentException("val");
+            }
+        }
+    }
+}

--- a/VisualRust.Shared/BuildOutputType.cs
+++ b/VisualRust.Shared/BuildOutputType.cs
@@ -50,5 +50,18 @@ namespace VisualRust.Shared
                     throw new ArgumentException("val");
             }
         }
+
+        public static string ToRustcString(this BuildOutputType val)
+        {
+            switch(val)
+            {
+                case BuildOutputType.Application:
+                    return "bin";
+                case BuildOutputType.Library:
+                    return "lib";
+                default:
+                    throw new ArgumentException("val");
+            }
+        }
     }
 }

--- a/VisualRust.Shared/Environment.cs
+++ b/VisualRust.Shared/Environment.cs
@@ -30,20 +30,33 @@ namespace VisualRust.Shared
             return GetAllInstallPaths().SelectMany(SniffTargets);
         }
 
-        private static IEnumerable<string> GetAllInstallPaths()
+        public static IEnumerable<string> FindCurrentUserInstallPaths()
         {
-            IEnumerable<string> installPaths;
             if(System.Environment.Is64BitOperatingSystem)
             {
-                installPaths = GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry64)
-                    .Union(GetInstallRoots(RegistryHive.LocalMachine, RegistryView.Registry64));
+                return GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry64)
+                    .Union(GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry32));
             }
             else
             {
-                installPaths = new string[0];
+                return GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry32);
             }
-            return installPaths.Union(GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry32))
-                .Union(GetInstallRoots(RegistryHive.LocalMachine, RegistryView.Registry32));
+        }
+
+        private static IEnumerable<string> GetAllInstallPaths()
+        {
+            if(System.Environment.Is64BitOperatingSystem)
+            {
+                return GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry64)
+                    .Union(GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry32))
+                    .Union(GetInstallRoots(RegistryHive.LocalMachine, RegistryView.Registry64))
+                    .Union(GetInstallRoots(RegistryHive.LocalMachine, RegistryView.Registry32));
+            }
+            else
+            {
+                return GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry32)
+                    .Union(GetInstallRoots(RegistryHive.LocalMachine, RegistryView.Registry32));
+            }
         }
 
         private static IEnumerable<string> GetInstallRoots(RegistryHive hive, RegistryView view)

--- a/VisualRust.Shared/Environment.cs
+++ b/VisualRust.Shared/Environment.cs
@@ -32,15 +32,18 @@ namespace VisualRust.Shared
 
         private static IEnumerable<string> GetAllInstallPaths()
         {
-            IEnumerable<string> installPaths = GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry32)
-                .Union(GetInstallRoots(RegistryHive.LocalMachine, RegistryView.Registry32));
+            IEnumerable<string> installPaths;
             if(System.Environment.Is64BitOperatingSystem)
             {
-                installPaths = installPaths
-                    .Union(GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry64))
+                installPaths = GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry64)
                     .Union(GetInstallRoots(RegistryHive.LocalMachine, RegistryView.Registry64));
             }
-            return installPaths;
+            else
+            {
+                installPaths = new string[0];
+            }
+            return installPaths.Union(GetInstallRoots(RegistryHive.CurrentUser, RegistryView.Registry32))
+                .Union(GetInstallRoots(RegistryHive.LocalMachine, RegistryView.Registry32));
         }
 
         private static IEnumerable<string> GetInstallRoots(RegistryHive hive, RegistryView view)

--- a/VisualRust.Shared/Environment.cs
+++ b/VisualRust.Shared/Environment.cs
@@ -36,11 +36,49 @@ namespace VisualRust.Shared
             return fullInstallKey != null ? fullInstallKey.ToString() : null;
         }
 
-        private static bool CanActuallyBuildTarget(string path, string target)
+        public static IEnumerable<string> FindInstalledTargets()
+        {
+            foreach(string path in System.Environment.GetEnvironmentVariable("PATH").Split(System.IO.Path.PathSeparator))
+            {
+                if(File.Exists(Path.Combine(path, "rustc.exe")) 
+                    && File.Exists(Path.Combine(path, "cargo.exe")))
+                foreach(string targetPath in SniffTargets(path))
+                {
+                    yield return targetPath;
+                }
+            }
+            RegistryKey installpath = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default).OpenSubKey(InnoPath);
+            if (installpath != null)
+            {
+                object fullInstallKey = installpath.GetValue(InnoKey);
+                if(fullInstallKey != null)
+                {
+                    foreach(string targetPath in SniffTargets(Path.Combine(fullInstallKey.ToString(), "bin")))
+                    {
+                        yield return targetPath;
+                    }
+                }
+            }
+        }
+
+        private static bool CanActuallyBuildTarget(string binPath, string target)
         {
             if(String.Equals(DefaultTarget, target, StringComparison.OrdinalIgnoreCase))
                 return true;
-            return Directory.Exists(Path.Combine(path, "rustlib", target));
+            return Directory.Exists(Path.Combine(binPath, "rustlib", target));
+        }
+
+        private static IEnumerable<string> SniffTargets(string binPath)
+        {
+            try
+            {
+                string root = Path.Combine(binPath, "rustlib");
+                return Directory.GetDirectories(root, "*-*-*").Select(p => p.Substring(root.Length + 1).ToLowerInvariant());
+            }
+            catch(IOException)
+            {
+                return new string[0];
+            }
         }
     }
 }

--- a/VisualRust.Shared/Environment.cs
+++ b/VisualRust.Shared/Environment.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Shared
+{
+    public class Environment
+    {
+        private const string InnoPath = @"Software\Microsoft\Windows\CurrentVersion\Uninstall\Rust_is1";
+        private const string InnoKey = "InstallLocation";
+
+        // I'm really torn between "default", "local", "native", "unspecified" and "any"
+        public const string DefaultTarget = "default";
+
+        /* 
+         * If the target is "default" just return first location
+         * Otherwise check for bin\rustlib\<target>
+         */
+        public static string FindInstallPath(string target)
+        {
+            foreach(string path in System.Environment.GetEnvironmentVariable("PATH").Split(System.IO.Path.PathSeparator))
+            {
+                if(File.Exists(Path.Combine(path, "rustc.exe")) 
+                    && File.Exists(Path.Combine(path, "cargo.exe"))
+                    && CanActuallyBuildTarget(path, target))
+                return path;
+            }
+            RegistryKey installpath = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default).OpenSubKey(InnoPath);
+            if (installpath == null)
+                return null;
+            object fullInstallKey = installpath.GetValue(InnoKey);
+            return fullInstallKey != null ? fullInstallKey.ToString() : null;
+        }
+
+        private static bool CanActuallyBuildTarget(string path, string target)
+        {
+            if(String.Equals(DefaultTarget, target, StringComparison.OrdinalIgnoreCase))
+                return true;
+            return Directory.Exists(Path.Combine(path, "rustlib", target));
+        }
+    }
+}

--- a/VisualRust.Shared/OptimizationLevel.cs
+++ b/VisualRust.Shared/OptimizationLevel.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Shared
+{
+    public enum OptimizationLevel
+    {
+        O0,
+        O1,
+        O2,
+        O3
+    }
+
+    public static class OptimizationLevelExtension
+    {
+        public static OptimizationLevel Parse(string val)
+        {
+            if(val == null)
+                return OptimizationLevel.O0;
+            if(val.Equals("0", StringComparison.OrdinalIgnoreCase))
+                return OptimizationLevel.O0;
+            if(val.Equals("1", StringComparison.OrdinalIgnoreCase))
+                return OptimizationLevel.O1;
+            if(val.Equals("2", StringComparison.OrdinalIgnoreCase))
+                return OptimizationLevel.O2;
+            if(val.Equals("3", StringComparison.OrdinalIgnoreCase))
+                return OptimizationLevel.O3;
+            return OptimizationLevel.O0;
+        }
+
+        public static string ToBuildString(this OptimizationLevel val)
+        {
+            switch(val)
+            {
+                case OptimizationLevel.O0:
+                    return "0";
+                case OptimizationLevel.O1:
+                    return "1";
+                case OptimizationLevel.O2:
+                    return "2";
+                case OptimizationLevel.O3:
+                    return "3";
+                default:
+                    throw new ArgumentException("val");
+            }
+        }
+
+        public static string ToDisplayString(this OptimizationLevel val)
+        {
+            switch(val)
+            {
+                case OptimizationLevel.O0:
+                    return "none (O0)";
+                case OptimizationLevel.O1:
+                    return "minimal (O1)";
+                case OptimizationLevel.O2:
+                    return "optimized (O2)";
+                case OptimizationLevel.O3:
+                    return "aggresive (O3)";
+                default:
+                    throw new ArgumentException("val");
+            }
+        }
+    }
+}

--- a/VisualRust.Shared/Properties/AssemblyInfo.cs
+++ b/VisualRust.Shared/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("VisualRust.Shared")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("VisualRust.Shared")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("76bc4a6e-cbf3-470b-b2d2-139e1604f9e0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/VisualRust.Shared/VisualRust.Shared.csproj
+++ b/VisualRust.Shared/VisualRust.Shared.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{9CF556AB-76FE-4C3D-AD0A-B64B3B9989B4}</ProjectGuid>
+    <ProjectGuid>{B99CC9EB-90F2-4040-9E66-418CC7042153}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>VisualRust.Build</RootNamespace>
-    <AssemblyName>VisualRust.Build</AssemblyName>
+    <RootNamespace>VisualRust.Shared</RootNamespace>
+    <AssemblyName>VisualRust.Shared</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -29,19 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-CI|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug-CI\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Tasks.v4.0" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -51,19 +39,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="RustcParsedMessage.cs" />
-    <None Include="VisualRust.Rust.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <Compile Include="Rustc.cs" />
+    <Compile Include="Environment.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RustcFactory.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\VisualRust.Shared\VisualRust.Shared.csproj">
-      <Project>{b99cc9eb-90f2-4040-9e66-418cc7042153}</Project>
-      <Name>VisualRust.Shared</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/VisualRust.Shared/VisualRust.Shared.csproj
+++ b/VisualRust.Shared/VisualRust.Shared.csproj
@@ -41,6 +41,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="OptimizationLevel.cs" />
+    <Compile Include="BuildOutputType.cs" />
     <Compile Include="Environment.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/VisualRust.Shared/VisualRust.Shared.csproj
+++ b/VisualRust.Shared/VisualRust.Shared.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>VisualRust.Shared</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\VisualRust\Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/VisualRust.Templates/Projects/Application/ApplicationProject.rsproj
+++ b/VisualRust.Templates/Projects/Application/ApplicationProject.rsproj
@@ -1,23 +1,26 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">default</Platform>
     <ProjectGuid>$guid1$</ProjectGuid>
     <OutputType>exe</OutputType>
+    <CrateName>$crate_name$</CrateName>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>bin\Debug\</OutputPath>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|default' ">
+    <LinkTimeOptimization>false</LinkTimeOptimization>
+    <DebugSymbols>true</DebugSymbols>
+    <OptimizationLevel>0</OptimizationLevel>
+    <PlatformTarget>default</PlatformTarget>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>bin\Release\</OutputPath>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|default' ">
+    <LinkTimeOptimization>false</LinkTimeOptimization>
+    <DebugSymbols>false</DebugSymbols>
+    <OptimizationLevel>2</OptimizationLevel>
+    <PlatformTarget>default</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="src\" />
-    <None Include="src\main.rs" />
+    <Code Include="src\main.rs" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\VisualRust\VisualRust.Rust.targets"></Import>
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
+  <Import Project="$(MSBuildExtensionsPath)\VisualRust\VisualRust.Rust.targets"/>
 </Project>

--- a/VisualRust.Templates/Projects/Library/LibraryProject.rsproj
+++ b/VisualRust.Templates/Projects/Library/LibraryProject.rsproj
@@ -1,23 +1,26 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">default</Platform>
     <ProjectGuid>$guid1$</ProjectGuid>
     <OutputType>library</OutputType>
+    <CrateName>$crate_name$</CrateName>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>bin\Debug\</OutputPath>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|default' ">
+    <LinkTimeOptimization>false</LinkTimeOptimization>
+    <DebugSymbols>true</DebugSymbols>
+    <OptimizationLevel>0</OptimizationLevel>
+    <PlatformTarget>default</PlatformTarget>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>bin\Release\</OutputPath>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|default' ">
+    <LinkTimeOptimization>false</LinkTimeOptimization>
+    <DebugSymbols>false</DebugSymbols>
+    <OptimizationLevel>2</OptimizationLevel>
+    <PlatformTarget>default</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="src\" />
-    <None Include="src\lib.rs" />
+    <Code Include="src\lib.rs" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\VisualRust\VisualRust.Rust.targets"></Import>
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
+  <Import Project="$(MSBuildExtensionsPath)\VisualRust\VisualRust.Rust.targets"/>
 </Project>

--- a/VisualRust.Test.Integration/MSBuild/Trivial/src/main.rs
+++ b/VisualRust.Test.Integration/MSBuild/Trivial/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello world");
+}

--- a/VisualRust.Test.Integration/MSBuild/Trivial/trivial.rsproj
+++ b/VisualRust.Test.Integration/MSBuild/Trivial/trivial.rsproj
@@ -1,0 +1,7 @@
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Folder Include="src\" />
+    <Code Include="src\main.rs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\VisualRust\VisualRust.Rust.targets"/>
+</Project>

--- a/VisualRust.Test.Integration/MSBuild/Trivial/trivial.rsproj
+++ b/VisualRust.Test.Integration/MSBuild/Trivial/trivial.rsproj
@@ -3,5 +3,5 @@
     <Folder Include="src\" />
     <Code Include="src\main.rs" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\VisualRust\VisualRust.Rust.targets"/>
+  <Import Project="..\..\VisualRust.Rust.targets"/>
 </Project>

--- a/VisualRust.Test.Integration/Package.cs
+++ b/VisualRust.Test.Integration/Package.cs
@@ -27,6 +27,7 @@ namespace VisualRust.Test.Integration
 
         [TestMethod]
         [HostType("VS IDE")]
+        [TestCategory("Explicit")]
         [TestProperty("VsHiveName", "12.0Exp")]
         public void PackageLoad()
         {
@@ -44,6 +45,7 @@ namespace VisualRust.Test.Integration
 
         [TestMethod]
         [HostType("VS IDE")]
+        [TestCategory("Explicit")]
         [TestProperty("VsHiveName", "12.0Exp")]
         public void CreateRustLibraryProject()
         {
@@ -77,6 +79,7 @@ namespace VisualRust.Test.Integration
 
         [TestMethod]
         [HostType("VS IDE")]
+        [TestCategory("Explicit")]
         [TestProperty("VsHiveName", "12.0Exp")]
         public void ExcludedNodesAreNotTracked()
         {
@@ -112,6 +115,7 @@ namespace VisualRust.Test.Integration
 
         [TestMethod]
         [HostType("VS IDE")]
+        [TestCategory("Explicit")]
         [TestProperty("VsHiveName", "12.0Exp")]
         public void AddExistingFileFromFolder()
         {
@@ -150,6 +154,7 @@ namespace VisualRust.Test.Integration
 
         [TestMethod]
         [HostType("VS IDE")]
+        [TestCategory("Explicit")]
         [TestProperty("VsHiveName", "12.0Exp")]
         public void CreateRustApplicationProject()
         {

--- a/VisualRust.Test.Integration/Project.cs
+++ b/VisualRust.Test.Integration/Project.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Deployment.WindowsInstaller;
+using System.IO;
+
+namespace VisualRust.Test.Integration
+{
+    [TestClass]
+    public class Project
+    {
+        [ClassInitialize]
+        public static void InstallRustLocally(TestContext testContext)
+        {
+            AssertNoRustInstalled();
+            Installer.SetInternalUI(InstallUIOptions.Silent);
+            Installer.InstallProduct(
+                @"Build\rust-1.0.0-beta-i686-pc-windows-gnu.msi",
+                String.Format("INSTALLDIR_USER=\"{0}\"", Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())));
+        }
+
+        [ClassCleanup]
+        public static void UninstallRustLocally()
+        {
+            Installer.ConfigureProduct("{17A31558-A8C0-4C44-A679-09F1B8732999}", 0, InstallState.Absent, "");
+        }
+
+        [TestCategory("Explicit")]
+        [TestMethod]
+        public void BuildTrivialProject()
+        {
+            var proj = new Microsoft.Build.Evaluation.Project(@"Build\Trivial\trivial.rsproj");
+            proj.Build("Build");
+        }
+
+        private static void AssertNoRustInstalled()
+        {
+            string[] userInstallPaths = Shared.Environment.FindCurrentUserInstallPaths().ToArray();
+            if(userInstallPaths.Length > 0)
+            {
+                string tabbedPaths = String.Join("\n", userInstallPaths);
+                Assert.Fail("Found existing user-specific rust installations:\n{0}", tabbedPaths);
+            }
+        }
+    }
+}

--- a/VisualRust.Test.Integration/Project.cs
+++ b/VisualRust.Test.Integration/Project.cs
@@ -6,6 +6,7 @@ using Microsoft.Deployment.WindowsInstaller;
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
+using Microsoft.Build.Evaluation;
 
 namespace VisualRust.Test.Integration
 {
@@ -51,11 +52,57 @@ namespace VisualRust.Test.Integration
         [TestMethod]
         public void BuildTrivialProject()
         {
-            var proj = new Microsoft.Build.Evaluation.Project(@"MSBuild\Trivial\trivial.rsproj");
+            var proj = new ProjectCollection().LoadProject(@"MSBuild\Trivial\trivial.rsproj");
             AssertBuildsProject(proj, "Build");
             Assert.IsTrue(File.Exists(@"MSBuild\Trivial\target\Debug\trivial.exe"));
             Directory.Delete(@"MSBuild\Trivial\obj", true);
             Directory.Delete(@"MSBuild\Trivial\target", true);
+        }
+
+        [TestCategory("Explicit")]
+        [TestMethod]
+        public void CleanWithoutBuild()
+        {
+            AssertBuildEnviromentIsClean(@"MSBuild\Trivial");
+            var proj = new ProjectCollection().LoadProject(@"MSBuild\Trivial\trivial.rsproj");
+            AssertBuildsProject(proj, "Clean");
+            AssertBuildEnviromentIsClean(@"MSBuild\Trivial");
+        }
+
+        [TestCategory("Explicit")]
+        [TestMethod]
+        public void CleanAfterBuild()
+        {
+            var proj = new ProjectCollection().LoadProject(@"MSBuild\Trivial\trivial.rsproj");
+            AssertBuildsProject(proj, "Build");
+            AssertBuildsProject(proj, "Clean");
+            AssertBuildEnviromentIsClean(@"MSBuild\Trivial");
+        }
+
+        private static void AssertBuildEnviromentIsClean(string path)
+        {
+            if(Directory.Exists(Path.Combine(path, "obj")))
+                AssertDirectoryIsEmpty(Path.Combine(path, "obj"));
+            if(Directory.Exists(Path.Combine(path, "target")))
+                AssertDirectoryIsEmpty(Path.Combine(path, "target"));
+        }
+
+
+        private static void AssertDirectoryIsEmpty(string path)
+        {
+            var files = Directory.EnumerateFiles(path).ToArray();
+            if(files.Length > 0)
+            {
+                Assert.Fail(
+                    "Directory {0} not empty. Files: {1}",
+                    path,
+                    String.Join(", ", files.Select(f => f.Substring(path.Length + 1))));
+            }
+            else
+            {
+                foreach(var dir in Directory.GetDirectories(path))
+                AssertDirectoryIsEmpty(dir);
+            }
         }
 
         private static void AssertBuildsProject(Microsoft.Build.Evaluation.Project proj, string target)

--- a/VisualRust.Test.Integration/Project.cs
+++ b/VisualRust.Test.Integration/Project.cs
@@ -44,7 +44,7 @@ namespace VisualRust.Test.Integration
         [ClassCleanup]
         public static void UninstallRustLocally()
         {
-            Installer.ConfigureProduct("{17A31558-A8C0-4C44-A679-09F1B8732999}", 0, InstallState.Absent, "");
+            Installer.ConfigureProduct("{35295818-DAA6-43A9-997B-11EB194EFB2F}", 0, InstallState.Absent, "");
         }
 
         [TestCategory("Explicit")]
@@ -53,6 +53,9 @@ namespace VisualRust.Test.Integration
         {
             var proj = new Microsoft.Build.Evaluation.Project(@"MSBuild\Trivial\trivial.rsproj");
             AssertBuildsProject(proj, "Build");
+            Assert.IsTrue(File.Exists(@"MSBuild\Trivial\target\Debug\trivial.exe"));
+            Directory.Delete(@"MSBuild\Trivial\obj", true);
+            Directory.Delete(@"MSBuild\Trivial\target", true);
         }
 
         private static void AssertBuildsProject(Microsoft.Build.Evaluation.Project proj, string target)

--- a/VisualRust.Test.Integration/VisualRust.Test.Integration.csproj
+++ b/VisualRust.Test.Integration/VisualRust.Test.Integration.csproj
@@ -110,13 +110,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Build\Trivial\trivial.rsproj">
+    <None Include="MSBuild\rust-1.0.0-beta.2-i686-pc-windows-gnu.msi" />
+    <None Include="MSBuild\Trivial\trivial.rsproj">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="Build\Trivial\src\main.rs">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Build\rust-1.0.0-beta-i686-pc-windows-gnu.msi">
+    <None Include="MSBuild\Trivial\src\main.rs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/VisualRust.Test.Integration/VisualRust.Test.Integration.csproj
+++ b/VisualRust.Test.Integration/VisualRust.Test.Integration.csproj
@@ -51,6 +51,10 @@
     <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Engine" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Deployment.WindowsInstaller, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
@@ -75,6 +79,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssertEx.cs" />
+    <Compile Include="Project.cs" />
     <Compile Include="Fake\FakeIOleComponentManager.cs" />
     <Compile Include="Fake\FakeIVsRegisterProjectTypes.cs" />
     <Compile Include="Fake\FakeIVsRunningDocumentTable.cs" />
@@ -95,10 +100,25 @@
       <Project>{475c4df2-4d4b-4f2c-9f27-414148dd6f11}</Project>
       <Name>VisualRust.Project</Name>
     </ProjectReference>
+    <ProjectReference Include="..\VisualRust.Shared\VisualRust.Shared.csproj">
+      <Project>{b99cc9eb-90f2-4040-9e66-418cc7042153}</Project>
+      <Name>VisualRust.Shared</Name>
+    </ProjectReference>
     <ProjectReference Include="..\VisualRust\VisualRust.csproj">
       <Project>{8b7b30f7-17c1-4ce8-baf4-88b086af7b25}</Project>
       <Name>VisualRust</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Build\Trivial\trivial.rsproj">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Build\Trivial\src\main.rs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Build\rust-1.0.0-beta-i686-pc-windows-gnu.msi">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/VisualRust.Test.Integration/VisualRust.Test.Integration.csproj
+++ b/VisualRust.Test.Integration/VisualRust.Test.Integration.csproj
@@ -96,6 +96,10 @@
       <Project>{cacb60a9-1e76-4f92-8831-b134a658c695}</Project>
       <Name>Microsoft.VisualStudio.Project</Name>
     </ProjectReference>
+    <ProjectReference Include="..\VisualRust.Build\VisualRust.Build.csproj">
+      <Project>{9cf556ab-76fe-4c3d-ad0a-b64b3b9989b4}</Project>
+      <Name>VisualRust.Build</Name>
+    </ProjectReference>
     <ProjectReference Include="..\VisualRust.Project\VisualRust.Project.csproj">
       <Project>{475c4df2-4d4b-4f2c-9f27-414148dd6f11}</Project>
       <Name>VisualRust.Project</Name>
@@ -110,9 +114,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="MSBuild\rust-1.0.0-beta.2-i686-pc-windows-gnu.msi" />
+    <None Include="MSBuild\rust-1.0.0-beta.2-i686-pc-windows-gnu.msi">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="MSBuild\Trivial\trivial.rsproj">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="MSBuild\Trivial\src\main.rs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/VisualRust.sln
+++ b/VisualRust.sln
@@ -26,6 +26,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualRust.Test", "VisualRu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualRust.Test.Integration", "VisualRust.Test.Integration\VisualRust.Test.Integration.csproj", "{5276348D-B99D-408B-A16E-4B2C527E7EA0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualRust.Shared", "VisualRust.Shared\VisualRust.Shared.csproj", "{B99CC9EB-90F2-4040-9E66-418CC7042153}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -165,6 +167,21 @@ Global
 		{5276348D-B99D-408B-A16E-4B2C527E7EA0}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{5276348D-B99D-408B-A16E-4B2C527E7EA0}.Release|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{5276348D-B99D-408B-A16E-4B2C527E7EA0}.Release|x86.ActiveCfg = Debug|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Debug-CI|Any CPU.ActiveCfg = Debug|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Debug-CI|Any CPU.Build.0 = Debug|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Debug-CI|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Debug-CI|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Debug-CI|x86.ActiveCfg = Debug|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B99CC9EB-90F2-4040-9E66-418CC7042153}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/VisualRust/Forms/BasePropertyPage.cs
+++ b/VisualRust/Forms/BasePropertyPage.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudioTools.Project;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Project.Forms
+{
+    [ComVisible(true)]
+    public abstract class BasePropertyPage : CommonPropertyPage
+    {
+        internal ProjectConfig[] Configs { get; private set; }
+
+        public override void SetObjects(uint cObjects, object[] ppunk)
+        {
+            if(ppunk != null)
+                Configs = ppunk.OfType<ProjectConfig>().ToArray();
+            else
+                Configs = new ProjectConfig[0];
+            base.SetObjects(cObjects, ppunk);
+        }
+    }
+}

--- a/VisualRust/Forms/BuildPropertyPage.cs
+++ b/VisualRust/Forms/BuildPropertyPage.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.VisualStudioTools.Project;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Project.Forms
+{
+    [ComVisible(true)]
+    [System.Runtime.InteropServices.Guid(Constants.BuildPropertyPage)]
+    public class BuildPropertyPage : CommonPropertyPage
+    {
+        private readonly BuildPropertyControl control;
+
+        public BuildPropertyPage()
+        {
+            control = new BuildPropertyControl();
+        }
+
+        public override System.Windows.Forms.Control Control
+        {
+            get { return control; }
+        }
+
+        public override void Apply()
+        {
+            IsDirty = false;
+        }
+
+        public override void LoadSettings()
+        {
+            Loading = true;
+            try {
+                //control.LoadSettings();
+            } finally {
+                Loading = false;
+            }
+        }
+
+        public override string Name
+        {
+            get { return "Build"; }
+        }
+    }
+}

--- a/VisualRust/Forms/BuildPropertyPage.cs
+++ b/VisualRust/Forms/BuildPropertyPage.cs
@@ -16,7 +16,7 @@ namespace VisualRust.Project.Forms
 
         public BuildPropertyPage()
         {
-            control = new BuildPropertyControl();
+            control = new BuildPropertyControl(isDirty => IsDirty = isDirty);
         }
 
         public override System.Windows.Forms.Control Control
@@ -26,6 +26,7 @@ namespace VisualRust.Project.Forms
 
         public override void Apply()
         {
+            control.ApplyConfig(this.Project);
             IsDirty = false;
         }
 

--- a/VisualRust/Forms/BuildPropertyPage.cs
+++ b/VisualRust/Forms/BuildPropertyPage.cs
@@ -33,7 +33,7 @@ namespace VisualRust.Project.Forms
         {
             Loading = true;
             try {
-                //control.LoadSettings();
+                control.LoadSettings(this.Project);
             } finally {
                 Loading = false;
             }

--- a/VisualRust/Forms/BuildPropertyPage.cs
+++ b/VisualRust/Forms/BuildPropertyPage.cs
@@ -10,7 +10,7 @@ namespace VisualRust.Project.Forms
 {
     [ComVisible(true)]
     [System.Runtime.InteropServices.Guid(Constants.BuildPropertyPage)]
-    public class BuildPropertyPage : CommonPropertyPage
+    public class BuildPropertyPage : BasePropertyPage
     {
         private readonly BuildPropertyControl control;
 
@@ -26,7 +26,7 @@ namespace VisualRust.Project.Forms
 
         public override void Apply()
         {
-            control.ApplyConfig(this.Project);
+            control.ApplyConfig(Configs);
             IsDirty = false;
         }
 
@@ -34,7 +34,7 @@ namespace VisualRust.Project.Forms
         {
             Loading = true;
             try {
-                control.LoadSettings(this.Project);
+                control.LoadSettings(Configs);
             } finally {
                 Loading = false;
             }

--- a/VisualRust/Forms/GeneralPropertyPage.cs
+++ b/VisualRust/Forms/GeneralPropertyPage.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.VisualStudioTools.Project;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Project.Forms
+{
+    [ComVisible(true)]
+    [System.Runtime.InteropServices.Guid(Constants.ApplicationPropertyPage)]
+    public class ApplicationPropertyPage : CommonPropertyPage
+    {
+        private readonly ApplicationPropertyControl control;
+
+        public ApplicationPropertyPage()
+        {
+            control = new ApplicationPropertyControl();
+        }
+
+        public override System.Windows.Forms.Control Control
+        {
+            get { return control; }
+        }
+
+        public override void Apply()
+        {
+            IsDirty = false;
+        }
+
+        public override void LoadSettings()
+        {
+            Loading = true;
+            try {
+                control.LoadSettings(this.Project);
+            } finally {
+                Loading = false;
+            }
+        }
+
+        public override string Name
+        {
+            get { return "General"; }
+        }
+    }
+}

--- a/VisualRust/Forms/GeneralPropertyPage.cs
+++ b/VisualRust/Forms/GeneralPropertyPage.cs
@@ -16,7 +16,7 @@ namespace VisualRust.Project.Forms
 
         public ApplicationPropertyPage()
         {
-            control = new ApplicationPropertyControl();
+            control = new ApplicationPropertyControl(isDirty => IsDirty = isDirty);
         }
 
         public override System.Windows.Forms.Control Control
@@ -26,6 +26,7 @@ namespace VisualRust.Project.Forms
 
         public override void Apply()
         {
+            control.ApplyConfig(this.Project);
             IsDirty = false;
         }
 

--- a/VisualRust/Forms/GeneralPropertyPage.cs
+++ b/VisualRust/Forms/GeneralPropertyPage.cs
@@ -10,7 +10,7 @@ namespace VisualRust.Project.Forms
 {
     [ComVisible(true)]
     [System.Runtime.InteropServices.Guid(Constants.ApplicationPropertyPage)]
-    public class ApplicationPropertyPage : CommonPropertyPage
+    public class ApplicationPropertyPage : BasePropertyPage
     {
         private readonly ApplicationPropertyControl control;
 

--- a/VisualRust/VisualRust.csproj
+++ b/VisualRust/VisualRust.csproj
@@ -167,6 +167,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Forms\BuildPropertyPage.cs" />
+    <Compile Include="Forms\GeneralPropertyPage.cs" />
     <Compile Include="Guids.cs" />
     <Compile Include="Racer\AutoCompleter.cs" />
     <Compile Include="Resources.Designer.cs">

--- a/VisualRust/VisualRust.csproj
+++ b/VisualRust/VisualRust.csproj
@@ -166,6 +166,7 @@
     </COMReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Forms\BasePropertyPage.cs" />
     <Compile Include="Forms\BuildPropertyPage.cs" />
     <Compile Include="Forms\GeneralPropertyPage.cs" />
     <Compile Include="Guids.cs" />

--- a/VisualRust/VisualRust.csproj
+++ b/VisualRust/VisualRust.csproj
@@ -166,6 +166,7 @@
     </COMReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Forms\BuildPropertyPage.cs" />
     <Compile Include="Guids.cs" />
     <Compile Include="Racer\AutoCompleter.cs" />
     <Compile Include="Resources.Designer.cs">

--- a/VisualRust/VisualRust.csproj
+++ b/VisualRust/VisualRust.csproj
@@ -261,6 +261,10 @@
       <Project>{e983e989-f83a-4643-896a-ad496bf647d0}</Project>
       <Name>RustLexer</Name>
     </ProjectReference>
+    <ProjectReference Include="..\VisualRust.Shared\VisualRust.Shared.csproj">
+      <Project>{b99cc9eb-90f2-4040-9e66-418cc7042153}</Project>
+      <Name>VisualRust.Shared</Name>
+    </ProjectReference>
     <ProjectReference Include="..\VisualRust.Templates\VisualRust.Templates.csproj">
       <Project>{59D94B96-1AF7-46F2-8790-AAB6DFAE8D9A}</Project>
       <Name>VisualRust.Templates</Name>

--- a/VisualRust/VisualRustPackage.cs
+++ b/VisualRust/VisualRustPackage.cs
@@ -58,6 +58,7 @@ namespace VisualRust
         LanguageVsTemplate="Rust")]
     [ProvideLanguageExtension(typeof(RustLanguage), ".rs")]
     [Guid(GuidList.guidVisualRustPkgString)]
+    [ProvideObject(typeof(Project.Forms.ApplicationPropertyPage))]
     [ProvideObject(typeof(Project.Forms.BuildPropertyPage))]
     public class VisualRustPackage : CommonProjectPackage
     {

--- a/VisualRust/VisualRustPackage.cs
+++ b/VisualRust/VisualRustPackage.cs
@@ -58,6 +58,7 @@ namespace VisualRust
         LanguageVsTemplate="Rust")]
     [ProvideLanguageExtension(typeof(RustLanguage), ".rs")]
     [Guid(GuidList.guidVisualRustPkgString)]
+    [ProvideObject(typeof(Project.Forms.BuildPropertyPage))]
     public class VisualRustPackage : CommonProjectPackage
     {
         private RunningDocTableEventsListener docEventsListener;


### PR DESCRIPTION
Now when you right click Visual Rust project and choose "Properties" you'll be able to actually set some things (debug level, output name, etc)