### PR TITLE
Disable support for custom project platforms/configurations

### DIFF
--- a/VisualRust.Project/RustConfigProvider.cs
+++ b/VisualRust.Project/RustConfigProvider.cs
@@ -41,14 +41,10 @@ namespace VisualRust.Project
             return project.MakeConfiguration(configName);
         }
 
-        public override int GetCfgProviderProperty(int propid, out object var) {
-            switch ((__VSCFGPROPID)propid) {
-                case __VSCFGPROPID.VSCFGPROPID_SupportsPlatformAdd:
-                case __VSCFGPROPID.VSCFGPROPID_SupportsPlatformDelete:
-                    var = true;
-                    return VSConstants.S_OK;
-            }
-            return base.GetCfgProviderProperty(propid, out var);
+        public override int GetCfgProviderProperty(int propid, out object var)
+        {
+          var = false;
+          return VSConstants.S_OK;
         }
     }
 }


### PR DESCRIPTION
I'm not 100% sure how it will interact with cargo. I'm putting it on hold until we get cargo support, instead of shipping something that we might end up scrapping and reworking soon.