### PR TITLE
Handle Un-/Comment and F1 commands in editor

### DIFF
--- a/VisualRust/RustCommentSelectionCommandHandler.cs
+++ b/VisualRust/RustCommentSelectionCommandHandler.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace VisualRust
+{
+    class RustCommentSelectionCommandHandler : VSCommandTarget<VSConstants.VSStd2KCmdID>
+    {
+        readonly ITextBuffer Buffer;
+        public RustCommentSelectionCommandHandler(IVsTextView vsTextView, IWpfTextView textView)
+            : base(vsTextView, textView)
+        {
+            Buffer = textView.TextBuffer;
+        }
+
+        protected override bool Execute(VSConstants.VSStd2KCmdID command, uint options, IntPtr pvaIn, IntPtr pvaOut)
+        {
+            if (TextView.Selection.IsEmpty) return false;
+
+
+            var snapshot = Buffer.CurrentSnapshot;
+            int start = TextView.Selection.Start.Position.Position;
+            int end = TextView.Selection.End.Position.Position;
+
+            // this is what we will store start offset in to get maximal indentation amount
+            int? insertStartOffset = null;
+
+            using (var edit = Buffer.CreateEdit())
+            {
+                while (start < end)
+                {
+                    var line = snapshot.GetLineFromPosition(start);
+                    var text = line.GetText();
+                    switch (command)
+                    {
+                        case VSConstants.VSStd2KCmdID.COMMENTBLOCK:
+                        case VSConstants.VSStd2KCmdID.COMMENT_BLOCK:
+                            {
+                                if (insertStartOffset == null) insertStartOffset = GetOffset(snapshot, start, end);
+                                if (!string.IsNullOrEmpty(text))
+                                    edit.Insert(line.Start.Position + insertStartOffset.GetValueOrDefault(), "//");
+
+                                break;
+                            }
+                        case VSConstants.VSStd2KCmdID.UNCOMMENTBLOCK:
+                        case VSConstants.VSStd2KCmdID.UNCOMMENT_BLOCK:
+                            {
+                                // NOTE: it is important to use the lexer here, because we want to keep doc comments
+                                //       (purely textual check would result in '///' being changed to '/')
+                                foreach (var token in Utils.LexString(line.GetText()))
+                                {
+                                    // TODO: how to deal with block comments and other multiline tokens?
+                                    if (token.Type == RustLexer.RustLexer.COMMENT)
+                                    {
+                                        edit.Delete(line.Start.Position + token.StartIndex, 2);
+                                    }
+                                    else if (token.Type != RustLexer.RustLexer.WHITESPACE)
+                                    {
+                                        break;
+                                    }
+                                }
+
+                                break;
+                            }
+                    }
+
+                    start = line.EndIncludingLineBreak.Position;
+                }
+
+                edit.Apply();
+            }
+
+            return true;
+        }
+
+        private int GetOffset(ITextSnapshot snapshot, int start, int end)
+        {
+            int offset = int.MaxValue;
+            while (start < end)
+            {
+                var line = snapshot.GetLineFromPosition(start);
+                var text = line.GetText();
+
+                for (int i = 0; i < text.Length; i++)
+                {
+                    if (!char.IsWhiteSpace(text[i]))
+                        offset = Math.Min(offset, i);
+                }
+
+                start = line.EndIncludingLineBreak.Position;
+            }
+
+            return offset == int.MaxValue ? 0 : offset;
+        }
+
+        protected override IEnumerable<VSConstants.VSStd2KCmdID> SupportedCommands
+        {
+            get
+            {
+                yield return VSConstants.VSStd2KCmdID.COMMENTBLOCK;
+                yield return VSConstants.VSStd2KCmdID.COMMENT_BLOCK;
+                yield return VSConstants.VSStd2KCmdID.UNCOMMENT_BLOCK;
+                yield return VSConstants.VSStd2KCmdID.UNCOMMENTBLOCK;
+            }
+        }
+
+        protected override VSConstants.VSStd2KCmdID ConvertFromCommandId(uint id)
+        {
+            return (VSConstants.VSStd2KCmdID)id;
+        }
+
+        protected override uint ConvertFromCommand(VSConstants.VSStd2KCmdID command)
+        {
+            return (uint)command;
+        }
+    }
+}

--- a/VisualRust/RustCommentSelectionCommandHandler.cs
+++ b/VisualRust/RustCommentSelectionCommandHandler.cs
@@ -18,9 +18,6 @@ namespace VisualRust
 
         protected override bool Execute(VSConstants.VSStd2KCmdID command, uint options, IntPtr pvaIn, IntPtr pvaOut)
         {
-            if (TextView.Selection.IsEmpty) return false;
-
-
             var snapshot = Buffer.CurrentSnapshot;
             int start = TextView.Selection.Start.Position.Position;
             int end = TextView.Selection.End.Position.Position;
@@ -30,7 +27,7 @@ namespace VisualRust
 
             using (var edit = Buffer.CreateEdit())
             {
-                while (start < end)
+                while (start <= end)
                 {
                     var line = snapshot.GetLineFromPosition(start);
                     var text = line.GetText();
@@ -79,7 +76,7 @@ namespace VisualRust
         private int GetOffset(ITextSnapshot snapshot, int start, int end)
         {
             int offset = int.MaxValue;
-            while (start < end)
+            while (start <= end)
             {
                 var line = snapshot.GetLineFromPosition(start);
                 var text = line.GetText();

--- a/VisualRust/RustCompletionCommandHandler.cs
+++ b/VisualRust/RustCompletionCommandHandler.cs
@@ -15,32 +15,6 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace VisualRust
 {
-    [Export(typeof(IVsTextViewCreationListener))]
-    [ContentType("rust")]
-    [TextViewRole(PredefinedTextViewRoles.Interactive)]
-    internal sealed class RustCompletionHandlerProvider : IVsTextViewCreationListener
-    {
-        [Import]
-        IVsEditorAdaptersFactoryService AdapterService { get; set; }
-
-        [Import]
-        internal SVsServiceProvider ServiceProvider { get; set; }
-
-        [Import]
-        internal ICompletionBroker CompletionBroker { get; set; }
-
-        public void VsTextViewCreated(IVsTextView textViewAdapter)
-        {
-            IWpfTextView textView = AdapterService.GetWpfTextView(textViewAdapter);
-            if (textView == null)
-                return;
-
-            Func<RustCompletionCommandHandler> createCommandHandler =
-               () => new RustCompletionCommandHandler(textViewAdapter, textView, CompletionBroker);
-            textView.Properties.GetOrCreateSingletonProperty(createCommandHandler);
-        }
-    }
-
     internal sealed class RustCompletionCommandHandler : IOleCommandTarget
     {
         private readonly IOleCommandTarget next;

--- a/VisualRust/RustCompletionCommandHandler.cs
+++ b/VisualRust/RustCompletionCommandHandler.cs
@@ -73,10 +73,10 @@ namespace VisualRust
                 {
                     case VSConstants.VSStd2KCmdID.TYPECHAR:
                         char ch = GetTypeChar(pvaIn);
-                        var tokensAtCursor = GetTokensAtCursor();
+                        var tokensAtCursor = Utils.GetTokensAtPosition(TextView.Caret.Position.BufferPosition);
 
-                        var leftTokenType = tokensAtCursor.Item1;
-                        var currentTokenType = tokensAtCursor.Item2;
+                        RustTokenTypes? leftTokenType = tokensAtCursor.Item1 != null ? (RustTokenTypes?)Utils.LexerTokenToRustToken(tokensAtCursor.Item1.Text, tokensAtCursor.Item1.Type) : null;
+                        RustTokenTypes? currentTokenType = tokensAtCursor.Item2 != null ? (RustTokenTypes?)Utils.LexerTokenToRustToken(tokensAtCursor.Item2.Text, tokensAtCursor.Item2.Type) : null;
 
                         RustTokenTypes[] cancelTokens = { RustTokenTypes.COMMENT, RustTokenTypes.STRING, RustTokenTypes.DOC_COMMENT, RustTokenTypes.WHITESPACE };
 
@@ -115,38 +115,6 @@ namespace VisualRust
             }
 
             return hresult;
-        }
-
-        private Tuple<RustTokenTypes?, RustTokenTypes?> GetTokensAtCursor()
-        {
-            SnapshotPoint caret = TextView.Caret.Position.BufferPosition;
-            var line = caret.GetContainingLine();
-            var tokens = Utils.LexString(line.GetText()).ToList();
-
-            if (tokens.Count == 0)
-                return Tuple.Create<RustTokenTypes?, RustTokenTypes?>(null, null);
-
-            int col = caret.Position - line.Start.Position;
-
-            IToken leftToken;
-            IToken currentToken = tokens.FirstOrDefault(t => col > t.StartIndex && col <= t.StopIndex);
-
-            if (currentToken != null)
-            {
-                if (currentToken == tokens.First())
-                    leftToken = null;
-                else
-                    leftToken = tokens[tokens.IndexOf(currentToken) - 1];
-            }
-            else
-            {
-                leftToken = tokens.Last();
-            }
-
-            RustTokenTypes? leftTokenType = leftToken != null ? (RustTokenTypes?)Utils.LexerTokenToRustToken(leftToken.Text, leftToken.Type) : null;
-            RustTokenTypes? currentTokenType = currentToken != null ? (RustTokenTypes?)Utils.LexerTokenToRustToken(currentToken.Text, currentToken.Type) : null;
-
-            return Tuple.Create(leftTokenType, currentTokenType);
         }
 
         private void RestartSession()

--- a/VisualRust/RustDocumentListener.cs
+++ b/VisualRust/RustDocumentListener.cs
@@ -32,6 +32,7 @@ namespace VisualRust
 
             textView.Properties.GetOrCreateSingletonProperty(() => new RustCompletionCommandHandler(textViewAdapter, textView, CompletionBroker));
             textView.Properties.GetOrCreateSingletonProperty(() => new RustCommentSelectionCommandHandler(textViewAdapter, textView));
+            textView.Properties.GetOrCreateSingletonProperty(() => new RustF1HelpCommandHandler(textViewAdapter, textView));
             // TODO: also handle FormatDocument and GoToDefiniton here in a similar way
         }
     }

--- a/VisualRust/RustDocumentListener.cs
+++ b/VisualRust/RustDocumentListener.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Utilities;
+
+namespace VisualRust
+{
+    [Export(typeof(IVsTextViewCreationListener))]
+    [ContentType("rust")]
+    [TextViewRole(PredefinedTextViewRoles.Interactive)]
+    internal sealed class RustDocumentListener : IVsTextViewCreationListener
+    {
+        [Import]
+        IVsEditorAdaptersFactoryService AdapterService { get; set; }
+
+        [Import]
+        internal SVsServiceProvider ServiceProvider { get; set; }
+
+        [Import]
+        internal ICompletionBroker CompletionBroker { get; set; }
+
+        public void VsTextViewCreated(IVsTextView textViewAdapter)
+        {
+            IWpfTextView textView = AdapterService.GetWpfTextView(textViewAdapter);
+            if (textView == null)
+                return;
+
+            textView.Properties.GetOrCreateSingletonProperty(() => new RustCompletionCommandHandler(textViewAdapter, textView, CompletionBroker));
+            textView.Properties.GetOrCreateSingletonProperty(() => new RustCommentSelectionCommandHandler(textViewAdapter, textView));
+            // TODO: also handle FormatDocument and GoToDefiniton here in a similar way
+        }
+    }
+}

--- a/VisualRust/RustF1HelpCommandHandler.cs
+++ b/VisualRust/RustF1HelpCommandHandler.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows.Threading;
+using Antlr4.Runtime;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace VisualRust
+{
+    class RustF1HelpCommandHandler : VSCommandTarget<VSConstants.VSStd97CmdID>
+    {
+        readonly ITextBuffer Buffer;
+
+        public RustF1HelpCommandHandler(IVsTextView vsTextView, IWpfTextView textView)
+            : base(vsTextView, textView)
+        {
+            Buffer = textView.TextBuffer;
+        }
+
+        protected override bool Execute(VSConstants.VSStd97CmdID command, uint options, IntPtr pvaIn, IntPtr pvaOut)
+        {
+            // TODO: This could consider more context than just the current lexer token,
+            //       especially for IDENTs we probably want the whole path.
+            //       Ideally we would even use the path after resolution (incorporating imported modules, etc)
+            var snapshot = Buffer.CurrentSnapshot;
+            var tokens = Utils.GetTokensAtPosition(TextView.Caret.Position.BufferPosition);
+            var leftToken = tokens.Item1;
+            var currentToken = tokens.Item2;
+
+            var searchToken = currentToken ?? leftToken;
+            if (searchToken == null)
+            {
+                // TODO: By returning false we fall back to the default MSDN page if we don't have a valid token/context.
+                //       Is this what we want?
+                return false;
+            }
+
+            var type = Utils.LexerTokenToRustToken(searchToken.Text, searchToken.Type);
+            var text = searchToken.Text;
+            String helpUrl;
+
+            // TODO: This "translation" should be done by a web service, as is the case with MSDN,
+            //       in order to decouple this plugin from the structure of the Rust documentation.
+            //       Furthermore, it is not clear whether referring to The Book is useful here.
+            switch (type)
+            {
+                case RustTokenTypes.IDENT:
+                    helpUrl = "https://doc.rust-lang.org/std/?search=" + text;
+                    break;
+                case RustTokenTypes.LIFETIME:
+                    helpUrl = "https://doc.rust-lang.org/book/lifetimes.html";
+                    break;
+                case RustTokenTypes.STRING:
+                    helpUrl = "https://doc.rust-lang.org/book/strings.html";
+                    break;
+                case RustTokenTypes.KEYWORD:
+                default:
+                    // TODO?
+                    return false;
+            }
+
+            // "run" the URL in the default browser
+            System.Diagnostics.Process.Start(helpUrl);
+            return true;
+        }
+
+        protected override IEnumerable<VSConstants.VSStd97CmdID> SupportedCommands
+        {
+            get
+            {
+                yield return VSConstants.VSStd97CmdID.F1Help;
+            }
+        }
+
+        protected override VSConstants.VSStd97CmdID ConvertFromCommandId(uint id)
+        {
+            return (VSConstants.VSStd97CmdID)id;
+        }
+
+        protected override uint ConvertFromCommand(VSConstants.VSStd97CmdID command)
+        {
+            return (uint)command;
+        }
+    }
+}

--- a/VisualRust/Utils.cs
+++ b/VisualRust/Utils.cs
@@ -15,6 +15,8 @@ using Microsoft.VisualStudio.Text.Operations;
 namespace VisualRust
 {
     using RustLexer;
+    using Microsoft.VisualStudio.Text;
+    using Antlr4.Runtime;
 
     static class Utils
     {
@@ -194,6 +196,34 @@ namespace VisualRust
             outWindow.GetPane(ref paneGuid, out pane);
             pane.OutputString(string.Format("[VisualRust]: " + s, args) + "\n");
             pane.Activate();
+        }
+
+        internal static Tuple<IToken, IToken> GetTokensAtPosition(SnapshotPoint snapshotPoint)
+        {
+            var line = snapshotPoint.GetContainingLine();
+            var tokens = Utils.LexString(line.GetText()).ToList();
+
+            if (tokens.Count == 0)
+                return Tuple.Create<IToken, IToken>(null, null);
+
+            int col = snapshotPoint.Position - line.Start.Position;
+
+            IToken leftToken;
+            IToken currentToken = tokens.FirstOrDefault(t => col > t.StartIndex && col <= t.StopIndex);
+
+            if (currentToken != null)
+            {
+                if (currentToken == tokens.First())
+                    leftToken = null;
+                else
+                    leftToken = tokens[tokens.IndexOf(currentToken) - 1];
+            }
+            else
+            {
+                leftToken = tokens.Last();
+            }
+
+            return Tuple.Create(leftToken, currentToken);
         }
     }
 

--- a/VisualRust/VSCommandTarget.cs
+++ b/VisualRust/VSCommandTarget.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio;
+
+namespace VisualRust
+{
+    /// <summary>
+    /// This is copied from SassyStudio (https://github.com/darrenkopp/SassyStudio)
+    /// </summary>
+    abstract class VSCommandTarget<T> : IOleCommandTarget
+    {
+        readonly IOleCommandTarget _NextCommandTarget;
+        protected readonly IWpfTextView TextView;
+        protected readonly Guid CommandGroupId;
+        protected readonly HashSet<uint> CommandIdSet;
+
+        protected VSCommandTarget(IVsTextView vsTextView, IWpfTextView textView)
+        {
+            TextView = textView;
+            CommandGroupId = typeof(T).GUID;
+            CommandIdSet = new HashSet<uint>(SupportedCommands.Select(x => ConvertFromCommand(x)));
+
+            _NextCommandTarget = AttachTo(vsTextView, this);
+        }
+
+        protected virtual bool IsEnabled { get { return true; } }
+        protected virtual bool SupportsAutomation { get { return false; } }
+        protected abstract IEnumerable<T> SupportedCommands { get; }
+        protected abstract T ConvertFromCommandId(uint id);
+        protected abstract uint ConvertFromCommand(T command);
+
+        protected abstract bool Execute(T command, uint options, IntPtr pvaIn, IntPtr pvaOut);
+
+        protected bool ExecuteNext(T command, uint options, IntPtr pvaIn, IntPtr pvaOut)
+        {
+            Guid pguidCmdGroup = CommandGroupId;
+
+            return _NextCommandTarget.Exec(ref pguidCmdGroup, ConvertFromCommand(command), options, pvaIn, pvaOut) == VSConstants.S_OK;
+        }
+
+        public int Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
+        {
+            if (SupportsAutomation || !VsShellUtilities.IsInAutomationFunction(VisualRustPackage.Instance))
+            {
+                if (pguidCmdGroup == CommandGroupId && CommandIdSet.Contains(nCmdID))
+                {
+                    bool result = Execute(ConvertFromCommandId(nCmdID), nCmdexecopt, pvaIn, pvaOut);
+
+                    if (result)
+                        return VSConstants.S_OK;
+                }
+            }
+
+            return _NextCommandTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+        }
+
+        public int QueryStatus(ref Guid pguidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText)
+        {
+            if (pguidCmdGroup == CommandGroupId)
+            {
+                for (int i = 0; i < cCmds; i++)
+                {
+                    if (CommandIdSet.Contains(prgCmds[i].cmdID))
+                    {
+                        if (IsEnabled)
+                        {
+                            prgCmds[i].cmdf = (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED);
+                            return VSConstants.S_OK;
+                        }
+
+                        prgCmds[0].cmdf = (uint)OLECMDF.OLECMDF_SUPPORTED;
+                    }
+                }
+            }
+
+            return _NextCommandTarget.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
+        }
+
+        static IOleCommandTarget AttachTo(IVsTextView view, IOleCommandTarget command)
+        {
+            IOleCommandTarget next;
+            view.AddCommandFilter(command, out next);
+            return next;
+        }
+    }
+}

--- a/VisualRust/VisualRust.csproj
+++ b/VisualRust/VisualRust.csproj
@@ -190,14 +190,17 @@
     <Compile Include="RustBraceMatcher.cs" />
     <Compile Include="RustClassifier.cs" />
     <Compile Include="RustClassifierProvider.cs" />
+    <Compile Include="RustCommentSelectionCommandHandler.cs" />
     <Compile Include="RustCompletionCommandHandler.cs" />
     <Compile Include="RustCompletionSource.cs" />
+    <Compile Include="RustDocumentListener.cs" />
     <Compile Include="RustTokenTypes.cs" />
     <Compile Include="Utils.cs" />
     <Compile Include="RustLanguage.cs" />
     <Compile Include="VisualRustPackage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VisualRustSmartIndent.cs" />
+    <Compile Include="VSCommandTarget.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Forms\RustOptionsPageControl.resx">

--- a/VisualRust/VisualRust.csproj
+++ b/VisualRust/VisualRust.csproj
@@ -194,6 +194,7 @@
     <Compile Include="RustCompletionCommandHandler.cs" />
     <Compile Include="RustCompletionSource.cs" />
     <Compile Include="RustDocumentListener.cs" />
+    <Compile Include="RustF1HelpCommandHandler.cs" />
     <Compile Include="RustTokenTypes.cs" />
     <Compile Include="Utils.cs" />
     <Compile Include="RustLanguage.cs" />

--- a/VisualRust/VisualRustPackage.cs
+++ b/VisualRust/VisualRustPackage.cs
@@ -15,6 +15,7 @@ using VisualRust.Project;
 using Microsoft.VisualStudioTools.Project;
 using Microsoft.VisualStudioTools.Project.Automation;
 using VisualRust.Options;
+using Microsoft.VisualStudio.ComponentModelHost;
 
 namespace VisualRust
 {
@@ -66,6 +67,7 @@ namespace VisualRust
     public class VisualRustPackage : CommonProjectPackage
     {
         private RunningDocTableEventsListener docEventsListener;
+        internal static VisualRustPackage Instance { get; private set; }
 
         /// <summary>
         /// Default constructor of the package.
@@ -91,6 +93,8 @@ namespace VisualRust
         protected override void Initialize()
         {
             base.Initialize();
+            Instance = this;
+
             docEventsListener = new RunningDocTableEventsListener((IVsRunningDocumentTable)GetService(typeof(SVsRunningDocumentTable)));
 
             Racer.AutoCompleter.Init();


### PR DESCRIPTION
This adresses #95 and #96, but the former is only rudimentarily implemented (I left quite a few `TODO` notes there). I also refactored RustCompletionCommandHandler to use the same helper class as the new commands, which I borrowed from [SassyStudio](https://github.com/darrenkopp/SassyStudio/blob/master/SassyStudio.2012/VSCommandTarget.cs).