### PR TITLE
Add rudimentry 'Go To Definition' support

### DIFF
--- a/VisualRust/Racer/RacerSingleton.cs
+++ b/VisualRust/Racer/RacerSingleton.cs
@@ -13,7 +13,7 @@ namespace VisualRust.Racer
     /// <remarks>
     /// racer.exe compiled (x86) as rustc -O -o racer.exe src\main.rs    
     /// </remarks>
-    public class AutoCompleter
+    public class RacerSingleton
     {
         private const string SystemRacerExecutable = "racer.exe";
         private const string BundledRacerExecutable = "racer-bf2373e.exe";
@@ -23,12 +23,12 @@ namespace VisualRust.Racer
         private string racerPathForExecution;
         private string racerSourcesLocation;
 
-        private static AutoCompleter instance;
+        private static RacerSingleton instance;
 
         /// <summary>
         /// Gets the singleton instance.
         /// </summary>
-        public static AutoCompleter Instance
+        public static RacerSingleton Instance
         {
             get
             {
@@ -45,10 +45,10 @@ namespace VisualRust.Racer
         public static void Init()
         {
             if (instance == null)
-                instance = new AutoCompleter();
+                instance = new RacerSingleton();
         }
 
-        private AutoCompleter()
+        private RacerSingleton()
         {
         }
 

--- a/VisualRust/RustCompletionSource.cs
+++ b/VisualRust/RustCompletionSource.cs
@@ -233,7 +233,7 @@ namespace VisualRust
                 int lineNumber = point.GetContainingLine().LineNumber;
                 int charNumber = GetColumn(point);
                 string args = string.Format("complete {0} {1} {2}", lineNumber + 1, charNumber, tmpFile.Path);
-                return Racer.AutoCompleter.Run(args);
+                return Racer.RacerSingleton.Run(args);
             }
         }
 

--- a/VisualRust/RustDocumentListener.cs
+++ b/VisualRust/RustDocumentListener.cs
@@ -33,7 +33,8 @@ namespace VisualRust
             textView.Properties.GetOrCreateSingletonProperty(() => new RustCompletionCommandHandler(textViewAdapter, textView, CompletionBroker));
             textView.Properties.GetOrCreateSingletonProperty(() => new RustCommentSelectionCommandHandler(textViewAdapter, textView));
             textView.Properties.GetOrCreateSingletonProperty(() => new RustF1HelpCommandHandler(textViewAdapter, textView));
-            // TODO: also handle FormatDocument and GoToDefiniton here in a similar way
+            textView.Properties.GetOrCreateSingletonProperty(() => new RustGoToDefinitionCommandHandler(ServiceProvider, textViewAdapter, textView));
+            // TODO: also handle FormatDocument here in a similar way
         }
     }
 }

--- a/VisualRust/RustGoToDefinitionCommandHandler.cs
+++ b/VisualRust/RustGoToDefinitionCommandHandler.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text;
+using VisualRust.Racer;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudioTools.Project;
+
+namespace VisualRust
+{
+    class RustGoToDefinitionCommandHandler : VSCommandTarget<VSConstants.VSStd97CmdID>
+    {
+        readonly ITextBuffer Buffer;
+        readonly IServiceProvider ServiceProvider;
+
+        public RustGoToDefinitionCommandHandler(IServiceProvider serviceProvider, IVsTextView vsTextView, IWpfTextView textView)
+            : base(vsTextView, textView)
+        {
+            Buffer = textView.TextBuffer;
+            ServiceProvider = serviceProvider;
+        }
+
+        protected override IEnumerable<VSConstants.VSStd97CmdID> SupportedCommands
+        {
+            get
+            {
+                yield return VSConstants.VSStd97CmdID.GotoDefn;
+            }
+        }
+
+        protected override VSConstants.VSStd97CmdID ConvertFromCommandId(uint id)
+        {
+            return (VSConstants.VSStd97CmdID)id;
+        }
+
+        protected override uint ConvertFromCommand(VSConstants.VSStd97CmdID command)
+        {
+            return (uint)command;
+        }
+
+        protected override bool Execute(VSConstants.VSStd97CmdID command, uint options, IntPtr pvaIn, IntPtr pvaOut)
+        {
+            var snapshot = Buffer.CurrentSnapshot;
+            var snapshotPoint = TextView.Caret.Position.BufferPosition;
+            var tokens = Utils.GetTokensAtPosition(snapshotPoint);
+
+            // TODO: Taken from Execute in RustF1HelpCommandHandler
+            var leftToken = tokens.Item1;
+            var currentToken = tokens.Item2;
+            var findToken = currentToken ?? leftToken;
+            if (findToken == null)
+            {
+                return false;
+            }
+
+            // TODO: Taken from AugmentCompletionSession
+            using (var tmpFile = new TemporaryFile(snapshot.GetText()))
+            {
+                var line = snapshotPoint.GetContainingLine();
+                // line.LineNumber uses 0 based indexing
+                int row = line.LineNumber + 1;
+                int column = snapshotPoint.Position - line.Start.Position;
+                var args = String.Format("find-definition {0} {1} {2}", row, column, tmpFile.Path);
+                var findOutput = Racer.RacerSingleton.Run(args);
+                if (Regex.IsMatch(findOutput, "^MATCH"))
+                {
+                    var results = findOutput.Substring(6).Split(',');
+                    // 1 based indexing
+                    var targetLine = Convert.ToInt32(results[1]) - 1;
+                    var targetColumn = Convert.ToInt32(results[2]);
+                    var fname = results[3];
+                    if (fname == tmpFile.Path)
+                    {
+                        // Current File
+                        var newLine = Buffer.CurrentSnapshot.Lines.ElementAt(targetLine);
+                        TextView.Caret.MoveTo(newLine.Start.Add(targetColumn));
+                        TextView.ViewScroller.EnsureSpanVisible(TextView.GetTextElementSpan(newLine.Start));
+                    }
+                    else
+                    {
+                        VsUtilities.NavigateTo(ServiceProvider, fname, Guid.Empty, targetLine, targetColumn);
+                    }
+                    return true;
+                }
+
+            }
+            return false;
+        }
+    }
+}

--- a/VisualRust/VisualRust.csproj
+++ b/VisualRust/VisualRust.csproj
@@ -179,7 +179,7 @@
     <Compile Include="Forms\RustOptionsPage.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="Racer\AutoCompleter.cs" />
+    <Compile Include="Racer\RacerSingleton.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -195,6 +195,7 @@
     <Compile Include="RustCompletionSource.cs" />
     <Compile Include="RustDocumentListener.cs" />
     <Compile Include="RustF1HelpCommandHandler.cs" />
+    <Compile Include="RustGoToDefinitionCommandHandler.cs" />
     <Compile Include="RustTokenTypes.cs" />
     <Compile Include="Utils.cs" />
     <Compile Include="RustLanguage.cs" />

--- a/VisualRust/VisualRustPackage.cs
+++ b/VisualRust/VisualRustPackage.cs
@@ -97,7 +97,7 @@ namespace VisualRust
 
             docEventsListener = new RunningDocTableEventsListener((IVsRunningDocumentTable)GetService(typeof(SVsRunningDocumentTable)));
 
-            Racer.AutoCompleter.Init();
+            Racer.RacerSingleton.Init();
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
I still need to do some cleanup, I'd like to reduce the duplication in some of the logic, the TODOs are what I'd like to figure out how to not duplicate. 

I wasn't able to get racer to find definitions in other files inside my own project. It did find definitions in the std library, and definitions that were in the same file. Not sure what's happening there, but I wanted to post this to see if someone else could try it out.