### PR TITLE
Make "Go To Definition" work on project files

### DIFF
--- a/VisualRust/RustGoToDefinitionCommandHandler.cs
+++ b/VisualRust/RustGoToDefinitionCommandHandler.cs
@@ -57,15 +57,17 @@ namespace VisualRust
             {
                 return false;
             }
+            
+            var dte = (EnvDTE.DTE)ServiceProvider.GetService(typeof(EnvDTE.DTE));
+            string filepath = dte.ActiveDocument.FullName;
 
-            // TODO: Taken from AugmentCompletionSession
-            using (var tmpFile = new TemporaryFile(snapshot.GetText()))
+            using (var tmpFile = new TemporaryFile(snapshot.GetText(), System.IO.Path.GetDirectoryName(filepath)))
             {
                 var line = snapshotPoint.GetContainingLine();
                 // line.LineNumber uses 0 based indexing
                 int row = line.LineNumber + 1;
                 int column = snapshotPoint.Position - line.Start.Position;
-                var args = String.Format("find-definition {0} {1} \"{2}\"", row, column, tmpFile.Path);
+                var args = String.Format("find-definition {0} {1} {2}", row, column, tmpFile.Path);
                 var findOutput = Racer.RacerSingleton.Run(args);
                 if (Regex.IsMatch(findOutput, "^MATCH"))
                 {

--- a/VisualRust/Utils.cs
+++ b/VisualRust/Utils.cs
@@ -300,19 +300,20 @@ namespace VisualRust
         public string Path { get; private set; }
 
         /// <summary>
-        ///  Creates a new, empty temporary file
+        ///  Creates a new temporary file with the argument string as UTF-8 content.
         /// </summary>
-        public TemporaryFile()
+        public TemporaryFile(string content) : this(content, System.IO.Path.GetTempPath())
         {
-            Path = System.IO.Path.GetTempFileName();            
         }
 
         /// <summary>
-        ///  Creates a new temporary file with the argument string as UTF-8 content.
+        /// Creates a temporary file at path with the argument string as UTF-8 content.
         /// </summary>
-        public TemporaryFile(string content)
-            : this()
+        /// <param name="content"></param>
+        /// <param name="directoryPath"></param>
+        public TemporaryFile(string content, string directoryPath)
         {
+            Path = System.IO.Path.Combine(directoryPath, System.IO.Path.GetRandomFileName());
             using (var sw = new StreamWriter(Path, false, new UTF8Encoding(false)))
             {
                 sw.Write(content);


### PR DESCRIPTION
This should work with files that are unsaved, yet still find the right definition.