### PR TITLE
Bump version to 0.1.1 and fix various gdb regressions

### DIFF
--- a/Microsoft.VisualStudio.Project/Properties/AssemblyInfo.cs
+++ b/Microsoft.VisualStudio.Project/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]
 
 [assembly: InternalsVisibleTo("VisualRust, PublicKey=00240000048000009400000006020000002400005253413100040000010001007755e184d6da3fe8b941736d1567d465beee5164177fa4517975dc035826e7cb94d733944a9df378cc038429af191f7ca06ddd4a146e6cd5882595030cfcf82b194cec14fe9745368245993236e5059f21a5721c0cad36c71bfa9101f41ac58c39318fdf91b7abf4ae799aa7e3ed5cb79efac57b651eb04c105219cbf1b2b69f")]
 [assembly: InternalsVisibleTo("VisualRust.Project, PublicKey=00240000048000009400000006020000002400005253413100040000010001007755e184d6da3fe8b941736d1567d465beee5164177fa4517975dc035826e7cb94d733944a9df378cc038429af191f7ca06ddd4a146e6cd5882595030cfcf82b194cec14fe9745368245993236e5059f21a5721c0cad36c71bfa9101f41ac58c39318fdf91b7abf4ae799aa7e3ed5cb79efac57b651eb04c105219cbf1b2b69f")]

--- a/RustLexer/Properties/AssemblyInfo.cs
+++ b/RustLexer/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]
 
 [assembly: System.CLSCompliant(true)]

--- a/VisualRust.Build/Properties/AssemblyInfo.cs
+++ b/VisualRust.Build/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]

--- a/VisualRust.Project/Properties/AssemblyInfo.cs
+++ b/VisualRust.Project/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]
 
 [assembly: InternalsVisibleTo("VisualRust, PublicKey=00240000048000009400000006020000002400005253413100040000010001007755e184d6da3fe8b941736d1567d465beee5164177fa4517975dc035826e7cb94d733944a9df378cc038429af191f7ca06ddd4a146e6cd5882595030cfcf82b194cec14fe9745368245993236e5059f21a5721c0cad36c71bfa9101f41ac58c39318fdf91b7abf4ae799aa7e3ed5cb79efac57b651eb04c105219cbf1b2b69f")]
 #if TEST

--- a/VisualRust.Setup/VisualRust.wxs
+++ b/VisualRust.Setup/VisualRust.wxs
@@ -3,7 +3,7 @@
   <Product Id="*"
            Name="Visual Rust"
            Language="1033"
-           Version="0.1.0.0"
+           Version="0.1.1.0"
            Manufacturer="The Piston Project"
            UpgradeCode="{B5CC88F7-BC23-4400-95D8-9EE3FA95CC3F}">
     <Package InstallerVersion="400"

--- a/VisualRust.Shared/Properties/AssemblyInfo.cs
+++ b/VisualRust.Shared/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]

--- a/VisualRust.Templates/Properties/AssemblyInfo.cs
+++ b/VisualRust.Templates/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]

--- a/VisualRust/Guids.cs
+++ b/VisualRust/Guids.cs
@@ -5,5 +5,6 @@ namespace VisualRust
     static class GuidList
     {
         public const string guidVisualRustPkgString = "40c1d2b5-528b-4966-a7b1-1974e3568abe";
+        public static Guid VisualRustCommandSet = new Guid("{91C8967B-EB9D-4904-AB07-4ACCA9C0ECFE}");
     };
 }

--- a/VisualRust/Properties/AssemblyInfo.cs
+++ b/VisualRust/Properties/AssemblyInfo.cs
@@ -27,8 +27,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]
 
 
 

--- a/VisualRust/VisualRust.csproj
+++ b/VisualRust/VisualRust.csproj
@@ -298,12 +298,18 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Resource Include="Resources\Package.ico" />
-    <VSCTCompile Include="VisualRust.vsct" />
+    <VSCTCompile Include="VisualRust.vsct" >
+      <ResourceName>Menus.ctmenu</ResourceName>
+    </VSCTCompile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Project\Microsoft.VisualStudio.Project.csproj">
       <Project>{cacb60a9-1e76-4f92-8831-b134a658c695}</Project>
       <Name>Microsoft.VisualStudio.Project</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MIEngine\src\MICore\MICore.csproj">
+      <Project>{12cc862d-95b7-4224-8e16-b928c6333677}</Project>
+      <Name>MICore</Name>
     </ProjectReference>
     <ProjectReference Include="..\MIEngine\src\MIDebugEngine\MIDebugEngine.csproj">
       <Project>{6D2688FE-6FD8-44A8-B96A-6037457F72A7}</Project>

--- a/VisualRust/VisualRust.vsct
+++ b/VisualRust/VisualRust.vsct
@@ -1,3 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable">
+  <Extern href="stdidcmd.h"/>
+  <Extern href="vsshlids.h"/>
+  <Commands package="VisualRustPackage">
+    <Buttons>
+      <Button guid="VisualRustCommandSet" id="VRDebugExec" priority="0x0100" type="Button">
+        <CommandFlag>AllowParams</CommandFlag>
+        <CommandFlag>CommandWellOnly</CommandFlag>
+        <Strings>
+          <ButtonText>Rust GDB Execute Command</ButtonText>
+          <CanonicalName>Debug.VRDebugExec</CanonicalName>
+          <LocCanonicalName>Debug.VRDebugExec</LocCanonicalName>
+        </Strings>
+      </Button>
+    </Buttons>
+  </Commands>
+
+  <Symbols>
+    <GuidSymbol name="VisualRustPackage" value="{40c1d2b5-528b-4966-a7b1-1974e3568abe}" />
+    <GuidSymbol name="VisualRustCommandSet" value="{91C8967B-EB9D-4904-AB07-4ACCA9C0ECFE}" >
+      <IDSymbol name="VRDebugExec" value="1" />
+    </GuidSymbol>
+  </Symbols>
 </CommandTable>

--- a/VisualRust/VisualRustPackage.cs
+++ b/VisualRust/VisualRustPackage.cs
@@ -34,7 +34,7 @@ namespace VisualRust
     [PackageRegistration(UseManagedResourcesOnly = true)]
     // This attribute is used to register the information needed to show this package
     // in the Help/About dialog of Visual Studio.
-    [InstalledProductRegistration("#110", "#112", "0.1", IconResourceID = 400)]
+    [InstalledProductRegistration("#110", "#112", "0.1.1", IconResourceID = 400)]
     [ProvideLanguageService(typeof(RustLanguage), "Rust", 100, 
         CodeSense = true, 
         DefaultToInsertSpaces = true,
@@ -143,7 +143,7 @@ namespace VisualRust
 
         public override string GetProductVersion()
         {
-            return "0.1";
+            return "0.1.1";
         }
     }
 }

--- a/VisualRust/source.extension.debug.vsixmanifest
+++ b/VisualRust/source.extension.debug.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="40c1d2b5-528b-4966-a7b1-1974e3568abe" Version="0.1" Language="en-US" Publisher="The Piston Project" />
+    <Identity Id="40c1d2b5-528b-4966-a7b1-1974e3568abe" Version="0.1.1" Language="en-US" Publisher="The Piston Project" />
     <DisplayName>Visual Rust</DisplayName>
     <Description>Visual Studio integration for the Rust programming language (http://www.rust-lang.org/)</Description>
     <License>LICENSE.txt</License>

--- a/VisualRust/source.extension.release.vsixmanifest
+++ b/VisualRust/source.extension.release.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="40c1d2b5-528b-4966-a7b1-1974e3568abe" Version="0.1" Language="en-US" Publisher="The Piston Project" />
+    <Identity Id="40c1d2b5-528b-4966-a7b1-1974e3568abe" Version="0.1.1" Language="en-US" Publisher="The Piston Project" />
     <DisplayName>Visual Rust</DisplayName>
     <Description>Visual Studio integration for the Rust programming language (http://www.rust-lang.org/)</Description>
     <License>LICENSE.txt</License>


### PR DESCRIPTION
During porting our gdb support to MIEngine source builds I accidentally omitted support for showing debuggee's console and didn't port Visual Studio command to interact with gdb. This PR brings them back.