### PR TITLE
Avoid null ref exception when package is not loaded

### DIFF
--- a/VisualRust.Shared/Environment.cs
+++ b/VisualRust.Shared/Environment.cs
@@ -18,12 +18,15 @@ namespace VisualRust.Shared
         public const string DefaultTarget = "default";
 
         /* 
-         * If the target is "default" just return first location
-         * Otherwise check for bin\rustlib\<target>
+         * If the target is "default" just return the first location with "bin\rustc.exe"
+         * Otherwise also require "bin\rustlib\<target>"
          */
         public static string FindInstallPath(string target)
         {
-            return GetAllInstallPaths().Select(p => Path.Combine(p, "bin")).FirstOrDefault(p => CanActuallyBuildTarget(p, target));
+            return GetAllInstallPaths()
+                .Select(p => Path.Combine(p, "bin"))
+                .Where(p => File.Exists(Path.Combine(p, "rustc.exe")))
+                .FirstOrDefault(p => CanActuallyBuildTarget(p, target));
         }
 
         public static IEnumerable<string> FindInstalledTargets()

--- a/VisualRust/VSCommandTarget.cs
+++ b/VisualRust/VSCommandTarget.cs
@@ -45,7 +45,7 @@ namespace VisualRust
 
         public int Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
         {
-            if (SupportsAutomation || !VsShellUtilities.IsInAutomationFunction(VisualRustPackage.Instance))
+            if (SupportsAutomation || (VisualRustPackage.Instance != null && !VsShellUtilities.IsInAutomationFunction(VisualRustPackage.Instance)))
             {
                 if (pguidCmdGroup == CommandGroupId && CommandIdSet.Contains(nCmdID))
                 {


### PR DESCRIPTION
This mitigates the symptoms of issue #181 

Maybe we need another fix to actually load the package even for non-Rust projects? I'm not sure if that's possible / desirable. But at least with this fix Rust files are editable from other kinds projects, syntax highlighting also works...
