### PR TITLE
Make all integration tests pass with VS 2015, Win10

### DIFF
--- a/VisualRust.Test.Integration/VisualRust.Test.Integration.csproj
+++ b/VisualRust.Test.Integration/VisualRust.Test.Integration.csproj
@@ -69,7 +69,7 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\VSSDK.Shell.12.12.0.4\lib\net45\Microsoft.VisualStudio.Shell.12.0.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\VSSDK.Shell.Immutable.10.10.0.4\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
@@ -149,6 +149,10 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.Project\Microsoft.VisualStudio.Project.csproj">
       <Project>{cacb60a9-1e76-4f92-8831-b134a658c695}</Project>
       <Name>Microsoft.VisualStudio.Project</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\VisualRust.Build\VisualRust.Build.csproj">
+      <Project>{9cf556ab-76fe-4c3d-ad0a-b64b3b9989b4}</Project>
+      <Name>VisualRust.Build</Name>
     </ProjectReference>
     <ProjectReference Include="..\VisualRust.Project\VisualRust.Project.csproj">
       <Project>{475c4df2-4d4b-4f2c-9f27-414148dd6f11}</Project>


### PR DESCRIPTION
I have half of tests failing without this change, and all passing with it... Could be a fix for issue #178. 
