### PR TITLE
Add multirust support

### DIFF
--- a/VisualRust.Build/Rustc.cs
+++ b/VisualRust.Build/Rustc.cs
@@ -184,12 +184,6 @@ namespace VisualRust.Build
 
         private bool ExecuteInner()
         {
-            string rustBinPath = VisualRust.Shared.Environment.FindInstallPath(VisualRust.Shared.Environment.DefaultTarget);
-            if(rustBinPath == null)
-            {
-              Log.LogError("No Rust installation detected. You can download official Rust installer from rust-lang.org/install.");
-                return false;
-            }
             StringBuilder sb = new StringBuilder();
             if (ConfigFlags.Length > 0)
                 sb.AppendFormat(" --cfg {0}", String.Join(",", ConfigFlags));
@@ -231,7 +225,7 @@ namespace VisualRust.Build
             if(installPath == null)
             {
                 if(String.Equals(target, Shared.Environment.DefaultTarget, StringComparison.OrdinalIgnoreCase))
-                    Log.LogError("Could not find a Rust installation.");
+                    Log.LogError("No Rust installation detected. You can download official Rust installer from rust-lang.org/install.");
                 else
                     Log.LogError("Could not find a Rust installation that can compile target {0}.", target);
                 return false;

--- a/VisualRust.Project/Launcher/LauncherEnviroment.cs
+++ b/VisualRust.Project/Launcher/LauncherEnviroment.cs
@@ -91,26 +91,7 @@ namespace VisualRust.Project.Launcher
             if(defaultInstallPath == null)
                 return null;
             string rustcPath = Path.Combine(defaultInstallPath, "rustc.exe");
-            string rustcHost = GetRustcHost(rustcPath);
-            return TargetTriple.Create(rustcHost);
-        }
-
-        static string GetRustcHost(string exePath)
-        {
-            ProcessStartInfo psi = new ProcessStartInfo
-            {
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                FileName = exePath,
-                RedirectStandardOutput = true,
-                Arguments = "-Vv"
-            };
-            Process proc = Process.Start(psi);
-            string verboseVersion = proc.StandardOutput.ReadToEnd();
-            Match hostMatch = Regex.Match(verboseVersion, "^host:\\s*(.+)$", RegexOptions.Multiline);
-            if (hostMatch.Groups.Count == 1)
-                return null;
-            return hostMatch.Groups[1].Value;
+            return Shared.Environment.GetTarget(rustcPath);
         }
     }
 }


### PR DESCRIPTION
This slightly changes the way we look for target triple supported by a compiler: we simply parse output of `rustc.exe -Vv` instead of sniffing folders. This works the same for official installer < 1.6, official installer >= 1.6 and multirust.
Previous solution was useful for cross-compiling, but I've never really tested it and I don't think anyone uses it with Visual Rust.