### PR TITLE
Start exposing Cargo output targets in project properties

### DIFF
--- a/Microsoft.VisualStudio.Project/CommonProjectNode.cs
+++ b/Microsoft.VisualStudio.Project/CommonProjectNode.cs
@@ -388,8 +388,8 @@ namespace Microsoft.VisualStudioTools.Project {
         /// <summary>
         /// Overriding main project loading method to inject our hierarachy of nodes.
         /// </summary>
-        protected override void Reload() {
-            base.Reload();
+        protected override void Reload(out int canceled) {
+            base.Reload(out canceled);
 
             BoldStartupItem();
 

--- a/Microsoft.VisualStudio.Project/Misc/NativeMethods.cs
+++ b/Microsoft.VisualStudio.Project/Misc/NativeMethods.cs
@@ -131,6 +131,8 @@ namespace Microsoft.VisualStudioTools.Project {
 
         DWL_MSGRESULT = 0,
 
+        SW_HIDE = 0,
+        SW_SHOW = 5,
         SW_SHOWNORMAL = 1,
 
         HTMENU = 5,
@@ -577,6 +579,12 @@ namespace Microsoft.VisualStudioTools.Project {
 
         [DllImport("user32", CallingConvention = CallingConvention.Winapi)]
         public static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+        [DllImport("user32", CallingConvention = CallingConvention.Winapi)]
+        public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, int flags);
+
+        [DllImport("user32", CallingConvention = CallingConvention.Winapi)]
+        public static extern bool GetWindowRect(IntPtr hWnd, out RECT[] rect);
 
         public static void SetErrorDescription(string description, params object[] args) {
             ICreateErrorInfo errInfo;
@@ -1182,5 +1190,6 @@ namespace Microsoft.VisualStudioTools.Project {
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 14)]
         public string cAlternateFileName;
     }
+
 }
 

--- a/Microsoft.VisualStudio.Project/ProjectNode.cs
+++ b/Microsoft.VisualStudio.Project/ProjectNode.cs
@@ -1581,7 +1581,7 @@ namespace Microsoft.VisualStudioTools.Project {
                     _diskNodes[this.filename] = this;
 
                     // now reload to fix up references
-                    this.Reload();
+                    this.Reload(out canceled);
                     successful = true;
                 } finally {
                     this.disableQueryEdit = false;
@@ -2194,9 +2194,9 @@ namespace Microsoft.VisualStudioTools.Project {
         /// <summary>
         /// Reload project from project file
         /// </summary>
-        protected virtual void Reload() {
+        protected virtual void Reload(out int canceled) {
             Debug.Assert(this.buildEngine != null, "There is no build engine defined for this project");
-
+            canceled = 0;
             try {
                 disableQueryEdit = true;
 

--- a/VisualRust.Build/VisualRust.Rust.targets
+++ b/VisualRust.Build/VisualRust.Rust.targets
@@ -5,6 +5,7 @@
              TaskName="Rustc"/>
 
   <PropertyGroup>
+    <ManifestPath Condition="'$(ManifestPath)' == ''">Cargo.toml</ManifestPath>
     <VisualRustTasksPath>$(MSBuildExtensionsPath)\VisualRust</VisualRustTasksPath>
     <OutputType Condition="'$(OutputType)' != 'library'">exe</OutputType>
     <_EntryPoint Condition="'$(OutputType)'=='exe'">src\main.rs</_EntryPoint>

--- a/VisualRust.Cargo/FieldMalformedError.cs
+++ b/VisualRust.Cargo/FieldMalformedError.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Cargo
+{
+    public class FieldMalformedError
+    {
+        public string Path { get; set; }
+        public bool Exists { get; set; }
+
+        public FieldMalformedError(string path, bool exists)
+        {
+            Path = path;
+            Exists = exists;
+        }
+
+        public override string ToString()
+        {
+            if(!Exists)
+                return String.Format("Value for the key `{0}` does not exist", Path);
+            else 
+                return String.Format("Value for the key `{0}` is empty", Path);
+        }
+    }
+}

--- a/VisualRust.Cargo/Manifest.cs
+++ b/VisualRust.Cargo/Manifest.cs
@@ -29,69 +29,16 @@ namespace VisualRust.Cargo
         }
 
         private readonly IntPtr manifest;
-
-        private string name;
-        public string Name
-        {
-            get { return name; }
-        }
-
-        private string version;
-        public string Version
-        {
-            get { return version; }
-        }
-
-        private string description;
-        public string Description
-        {
-            get { return description; }
-        }
-
-        private string[] authors;
-        public string[] Authors
-        {
-            get { return authors; }
-        }
-
-        private string documentation;
-        public string Documentation
-        {
-            get { return documentation; }
-        }
-
-        private string homepage;
-        public string Homepage
-        {
-            get { return homepage; }
-        }
-
-        private string repository;
-        public string Repository
-        {
-            get { return repository; }
-        }
-
-        private string license;
-        public string License
-        {
-            get { return license; }
-        }
-
-        Dependency[] dependencies;
-        public Dependency[] Dependencies
-        {
-            get { return dependencies; }
-        }
-
-        OutputTarget[] outputTargets;
-        public OutputTarget[] OutputTargets
-        {
-            get { return outputTargets; }
-        }
-
-        public string libName { get; private set; }
-        public string path { get; private set; }
+        public string Name { get; set; }
+        public string Version { get; set; }
+        public string Description { get; set; }
+        public string[] Authors { get; set; }
+        public string Documentation { get; set; }
+        public string Homepage { get; set; }
+        public string Repository { get; set; }
+        public string License { get; set; }
+        public Dependency[] Dependencies { get; set; }
+        public OutputTarget[] OutputTargets { get; set; }
 
         private Manifest(IntPtr handle)
         {
@@ -110,7 +57,7 @@ namespace VisualRust.Cargo
             Manifest manifest = new Manifest(manifestPtr);
             HashSet<EntryMismatchError> mismatchErrors = manifest.Load();
             IList<FieldMalformedError> validateErrors = manifest.Validate();
-            if(mismatchErrors.Count > 0 || validateErrors.Count > 0)
+            if (mismatchErrors.Count > 0 || validateErrors.Count > 0)
             {
                 loadErrors = new ManifestErrors(mismatchErrors, validateErrors);
                 return null;
@@ -120,6 +67,16 @@ namespace VisualRust.Cargo
                 loadErrors = null;
                 return manifest;
             }
+        }
+
+        public static Manifest CreateFake(string name, string version)
+        {
+            var manifest = new Manifest(IntPtr.Zero);
+            manifest.Name = name;
+            manifest.Version = version;
+            manifest.Dependencies = new Dependency[0];
+            manifest.OutputTargets = new OutputTarget[0];
+            return manifest;
         }
 
         static IntPtr Parse(string text, out string error)
@@ -146,27 +103,25 @@ namespace VisualRust.Cargo
         HashSet<EntryMismatchError> Load()
         {
             HashSet<EntryMismatchError> errors = new HashSet<EntryMismatchError>(new MismatchComparer());
-            name = GetString(errors, "package", "name");
-            version = GetString(errors, "package", "version");
-            authors = GetStringArray(errors, "package", "authors");
-            description = GetString(errors, "package", "description");
-            documentation = GetString(errors, "package", "documentation");
-            homepage = GetString(errors, "package", "homepage");
-            repository = GetString(errors, "package", "repository");
-            license = GetString(errors, "package", "license");
-            libName = GetString(errors, "lib", "name");
-            path = GetString(errors, "lib", "path");
-            dependencies = GetDependencies(errors);
-            outputTargets = GetOutputTargets(errors);
+            Name = GetString(errors, "package", "name");
+            Version = GetString(errors, "package", "version");
+            Authors = GetStringArray(errors, "package", "authors");
+            Description = GetString(errors, "package", "description");
+            Documentation = GetString(errors, "package", "documentation");
+            Homepage = GetString(errors, "package", "homepage");
+            Repository = GetString(errors, "package", "repository");
+            License = GetString(errors, "package", "license");
+            Dependencies = GetDependencies(errors);
+            OutputTargets = GetOutputTargets(errors);
             return errors;
         }
 
         IList<FieldMalformedError> Validate()
         {
             List<FieldMalformedError> errors = new List<FieldMalformedError>(2);
-            if(String.IsNullOrWhiteSpace(Name))
+            if (String.IsNullOrWhiteSpace(Name))
                 errors.Add(new FieldMalformedError("package.name", Name == null));
-            if(String.IsNullOrWhiteSpace(Version))
+            if (String.IsNullOrWhiteSpace(Version))
                 errors.Add(new FieldMalformedError("package.version", Version == null));
             return errors;
         }

--- a/VisualRust.Cargo/ManifestErrors.cs
+++ b/VisualRust.Cargo/ManifestErrors.cs
@@ -7,15 +7,26 @@ namespace VisualRust.Cargo
     {
         public string ParseError { get; private set; }
         public HashSet<EntryMismatchError> LoadErrors { get; private set; }
+        public IList<FieldMalformedError> ValidationErrors { get; private set; }
 
         public ManifestErrors(string parseError)
         {
             ParseError = parseError;
         }
 
-        public ManifestErrors(HashSet<EntryMismatchError> errors)
+        public ManifestErrors(HashSet<EntryMismatchError> mismatchErrors, IList<FieldMalformedError> validationErrors)
         {
-            LoadErrors = errors;
+            LoadErrors = mismatchErrors;
+            ValidationErrors = validationErrors;
+        }
+
+        public string[] GetErrors()
+        {
+            if(ParseError != null)
+                return new string[] {  ParseError };
+            return LoadErrors.Select(e => e.ToString())
+                             .Union(ValidationErrors.Select(e => e.ToString()))
+                             .ToArray();
         }
     }
 }

--- a/VisualRust.Cargo/OutputTarget.cs
+++ b/VisualRust.Cargo/OutputTarget.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace VisualRust.Cargo
+{
+    public class OutputTarget
+    {
+        public string Type { get; private set; }
+        public string Name { get; private set; }
+        public string Path { get; private set; }
+        public bool Test { get; private set; }
+        public bool Doctest { get; private set; }
+        public bool Bench { get; private set; }
+        public bool Doc { get; private set; }
+        public bool Plugin { get; private set; }
+        public bool Harness { get; private set; }
+
+        internal OutputTarget(RawOutputTarget t)
+        {
+            Type = t.Type.ToString();
+            Name = t.Name.ToString();
+            Path = t.Path.ToString();
+            Test = t.Test;
+            Doctest = t.Doctest;
+            Bench = t.Bench;
+            Doc = t.Doc;
+            Plugin = t.Plugin;
+            Harness = t.Harness;
+        }
+    }
+
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct RawOutputTarget
+    {
+        public Utf8String Type;
+        public Utf8String Name;
+        public Utf8String Path;
+        public bool Test;
+        public bool Doctest;
+        public bool Bench;
+        public bool Doc;
+        public bool Plugin;
+        public bool Harness;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct RawOutputTargetArray
+    {
+        public IntPtr Buffer;
+        public int Length;
+
+        public OutputTarget[] ToArray()
+        {
+            if (Buffer == IntPtr.Zero)
+                return new OutputTarget[0];
+            var buffer = new OutputTarget[Length];
+            for (int i = 0; i < Length; i++)
+            {
+                unsafe
+                {
+                    RawOutputTarget* current = ((RawOutputTarget*)Buffer) + i;
+                    buffer[i] = new OutputTarget(*current);
+                }
+            }
+            return buffer;
+        }
+    }
+}

--- a/VisualRust.Cargo/OutputTarget.cs
+++ b/VisualRust.Cargo/OutputTarget.cs
@@ -5,7 +5,7 @@ namespace VisualRust.Cargo
 {
     public class OutputTarget
     {
-        public string Type { get; private set; }
+        public OutputTargetType Type { get; private set; }
         public string Name { get; private set; }
         public string Path { get; private set; }
         public bool Test { get; private set; }
@@ -17,7 +17,7 @@ namespace VisualRust.Cargo
 
         internal OutputTarget(RawOutputTarget t)
         {
-            Type = t.Type.ToString();
+            Type = OutputTargetTypeExtensions.FromString(t.Type.ToString());
             Name = t.Name.ToString();
             Path = t.Path.ToString();
             Test = t.Test;

--- a/VisualRust.Cargo/OutputTargetType.cs
+++ b/VisualRust.Cargo/OutputTargetType.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Cargo
+{
+    public enum OutputTargetType
+    {
+        Library,
+        Binary,
+        Benchmark,
+        Test,
+        Example
+    }
+
+    public static class OutputTargetTypeExtensions
+    {
+        public static OutputTargetType FromString(string type)
+        {
+            switch(type)
+            {
+                case "lib":
+                    return OutputTargetType.Library;
+                case "bin":
+                    return OutputTargetType.Binary;
+                case "bench":
+                    return OutputTargetType.Benchmark;
+                case "test":
+                    return OutputTargetType.Test;
+                case "example":
+                    return OutputTargetType.Example;
+            }
+            throw new ArgumentException(null, "type");
+        }
+
+        
+        public static string ToTypeString(OutputTargetType type)
+        {
+            switch(type)
+            {
+                case OutputTargetType.Library:
+                    return "lib";
+                case OutputTargetType.Binary:
+                    return "bin";
+                case OutputTargetType.Benchmark:
+                    return "bench";
+                case OutputTargetType.Test:
+                    return "test";
+                case OutputTargetType.Example:
+                    return "example";
+            }
+            throw new ArgumentException(null, "type");
+        }
+    }
+}

--- a/VisualRust.Cargo/OutputTargetsQueryResult.cs
+++ b/VisualRust.Cargo/OutputTargetsQueryResult.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace VisualRust.Cargo
+{
+    internal struct OutputTargetsQueryResult : IDisposable
+    {
+        public RawOutputTargetArray Targets;
+        public RawDependencyErrorArray Errors;
+
+        public void Dispose()
+        {
+            SafeNativeMethods.free_output_targets_result(this);
+        }
+    }
+}

--- a/VisualRust.Cargo/SafeNativeMethods.cs
+++ b/VisualRust.Cargo/SafeNativeMethods.cs
@@ -9,31 +9,31 @@ namespace VisualRust.Cargo
 {
     static class SafeNativeMethods
     {
-        [DllImport("vist_toml.dll")]
+        [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void global_init();
 
-        [DllImport("vist_toml.dll")]
+        [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void free_strbox(Utf8String s);
 
-        [DllImport("vist_toml.dll")]
+        [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void free_strbox_array(Utf8StringArray s);
 
-        [DllImport("vist_toml.dll")]
+        [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void free_dependencies_result(DependenciesQueryResult s);
 
-        [DllImport("vist_toml.dll")]
+        [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern ParseResult load_from_utf16(IntPtr data, int length);
 
-        [DllImport("vist_toml.dll")]
+        [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void free_manifest(IntPtr manifest);
 
-        [DllImport("vist_toml.dll")]
+        [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern StringQueryResult get_string(IntPtr manifest, RawSlice slice);
 
-        [DllImport("vist_toml.dll")]
+        [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern StringArrayQueryResult get_string_array(IntPtr manifest, RawSlice slice);
 
-        [DllImport("vist_toml.dll")]
+        [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern DependenciesQueryResult get_dependencies(IntPtr manifest);
     }
 }

--- a/VisualRust.Cargo/SafeNativeMethods.cs
+++ b/VisualRust.Cargo/SafeNativeMethods.cs
@@ -20,6 +20,9 @@ namespace VisualRust.Cargo
 
         [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void free_dependencies_result(DependenciesQueryResult s);
+        
+        [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void free_output_targets_result(OutputTargetsQueryResult s);
 
         [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern ParseResult load_from_utf16(IntPtr data, int length);
@@ -35,5 +38,8 @@ namespace VisualRust.Cargo
 
         [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern DependenciesQueryResult get_dependencies(IntPtr manifest);
+
+        [DllImport("vist_toml.dll", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern OutputTargetsQueryResult get_output_targets(IntPtr manifest);
     }
 }

--- a/VisualRust.Cargo/VisualRust.Cargo.csproj
+++ b/VisualRust.Cargo/VisualRust.Cargo.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>VisualRust.Cargo</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\VisualRust\Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />

--- a/VisualRust.Cargo/VisualRust.Cargo.csproj
+++ b/VisualRust.Cargo/VisualRust.Cargo.csproj
@@ -48,8 +48,11 @@
     <Compile Include="DependenciesQueryResult.cs" />
     <Compile Include="Dependency.cs" />
     <Compile Include="EntryMismatchError.cs" />
+    <Compile Include="FieldMalformedError.cs" />
     <Compile Include="ManifestErrors.cs" />
     <Compile Include="Manifest.cs" />
+    <Compile Include="OutputTarget.cs" />
+    <Compile Include="OutputTargetsQueryResult.cs" />
     <Compile Include="ParseResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DependencyError.cs" />

--- a/VisualRust.Cargo/VisualRust.Cargo.csproj
+++ b/VisualRust.Cargo/VisualRust.Cargo.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Manifest.cs" />
     <Compile Include="OutputTarget.cs" />
     <Compile Include="OutputTargetsQueryResult.cs" />
+    <Compile Include="OutputTargetType.cs" />
     <Compile Include="ParseResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DependencyError.cs" />

--- a/VisualRust.Project/Constants.cs
+++ b/VisualRust.Project/Constants.cs
@@ -11,6 +11,7 @@ namespace VisualRust.Project
         public const string BuildPropertyPage = "10C47C08-3645-42C8-BBCA-BCBAA0129DF5";
         public const string ApplicationPropertyPage = "7B1CA802-91F7-4EF4-A1C0-83E40BA72429";
         public const string DebugPropertyPage = "F85DDD2A-EA8D-4CAD-A796-43407E8D91A0";
+        public const string TargetOutputsPage = "63BBED13-1954-42C7-AEE0-4A60AF397AF3";
 
         public const string BuiltinDebugger = "Built-in Debugger";
         public const string GdbDebugger = "GDB Debugger";

--- a/VisualRust.Project/Controls/AutoOutputTargetViewModel.cs
+++ b/VisualRust.Project/Controls/AutoOutputTargetViewModel.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VisualRust.Cargo;
+
+namespace VisualRust.Project.Controls
+{
+    abstract class AutoOutputTargetViewModel : IOutputTargetViewModel
+    {
+        protected const string AutoDetect = "(auto-detect)";
+
+        protected Manifest Manifest { get; private set; }
+
+        internal AutoOutputTargetViewModel(Manifest m)
+        {
+            this.Manifest = m;
+        }
+        public abstract OutputTargetType Type { get; }
+        public string TabName { get { return AutoDetect; } }
+        public abstract string Name { get; }
+        public abstract string Path { get; }
+        public virtual bool Bench { get { return true; } }
+        public virtual bool Doc { get { return false; } }
+        public virtual bool Doctest { get { return false; } }
+        public virtual bool Harness { get { return true; } }
+        public virtual bool Plugin { get { return false; } }
+        public virtual bool Test { get { return true; } }
+        public virtual bool IsReadOnly { get { return true; } }
+    }
+}

--- a/VisualRust.Project/Controls/BenchmarkAutoOutputTargetViewModel.cs
+++ b/VisualRust.Project/Controls/BenchmarkAutoOutputTargetViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using VisualRust.Cargo;
+
+namespace VisualRust.Project.Controls
+{
+    internal class BenchmarkAutoOutputTargetViewModel : AutoOutputTargetViewModel
+    {
+        public BenchmarkAutoOutputTargetViewModel(Manifest m) : base(m)
+        {
+        }
+
+        public override OutputTargetType Type { get { return OutputTargetType.Benchmark; } }
+        public override string Name { get { return AutoDetect; } }
+        public override string Path { get { return @"benches\*.rs"; } }
+    }
+}

--- a/VisualRust.Project/Controls/BinaryAutoOutputTargetViewModel.cs
+++ b/VisualRust.Project/Controls/BinaryAutoOutputTargetViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using VisualRust.Cargo;
+
+namespace VisualRust.Project.Controls
+{
+    internal class BinaryAutoOutputTargetViewModel : AutoOutputTargetViewModel
+    {
+        public BinaryAutoOutputTargetViewModel(Manifest m) : base(m)
+        {
+        }
+
+        public override OutputTargetType Type { get { return OutputTargetType.Binary; } }
+        public override string Name { get { return Manifest.Name; } }
+        public override string Path { get { return @"src\main.rs"; } }
+    }
+}

--- a/VisualRust.Project/Controls/ExampleAutoOutputTargetViewModel.cs
+++ b/VisualRust.Project/Controls/ExampleAutoOutputTargetViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using VisualRust.Cargo;
+
+namespace VisualRust.Project.Controls
+{
+    internal class ExampleAutoOutputTargetViewModel : AutoOutputTargetViewModel
+    {
+        public ExampleAutoOutputTargetViewModel(Manifest m) : base(m)
+        {
+        }
+
+        public override OutputTargetType Type { get { return OutputTargetType.Example; } }
+        public override string Name { get { return AutoDetect; } }
+        public override string Path { get { return @"examples\*.rs"; } }
+    }
+}

--- a/VisualRust.Project/Controls/IOutputTargetViewModel.cs
+++ b/VisualRust.Project/Controls/IOutputTargetViewModel.cs
@@ -1,0 +1,19 @@
+﻿using VisualRust.Cargo;
+
+namespace VisualRust.Project.Controls
+{
+    public interface IOutputTargetViewModel
+    {
+        OutputTargetType Type { get; }
+        string TabName { get; }
+        string Name { get; }
+        string Path { get; }
+        bool Test { get; }
+        bool Doctest { get; }
+        bool Bench { get; }
+        bool Doc { get; }
+        bool Plugin { get; }
+        bool Harness { get; }
+        bool IsReadOnly { get; }
+    }
+}

--- a/VisualRust.Project/Controls/IPropertyPageContext.cs
+++ b/VisualRust.Project/Controls/IPropertyPageContext.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualRust.Project.Controls
+{
+    public interface IPropertyPageContext
+    {
+        event EventHandler DirtyChanged;
+        bool IsDirty { get; }
+        void Apply();
+    }
+}

--- a/VisualRust.Project/Controls/LibraryAutoOutputTargetViewModel.cs
+++ b/VisualRust.Project/Controls/LibraryAutoOutputTargetViewModel.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VisualRust.Cargo;
+using VisualRust.Project.Controls;
+
+namespace VisualRust.Project.Controls
+{
+    class LibraryAutoOutputTargetViewModel : AutoOutputTargetViewModel
+    {
+        public LibraryAutoOutputTargetViewModel(Manifest m) : base(m)
+        {
+        }
+
+        public override OutputTargetType Type { get { return OutputTargetType.Library; } }
+        public override string Name { get { return Manifest.Name; } }
+        public override string Path { get { return @"src\lib.rs"; } }
+    }
+}

--- a/VisualRust.Project/Controls/OpenManifestErrorWindow.xaml
+++ b/VisualRust.Project/Controls/OpenManifestErrorWindow.xaml
@@ -1,0 +1,52 @@
+﻿<Window
+    x:Class="VisualRust.Project.Controls.OpenManifestErrorWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+    xmlns:local="clr-namespace:VisualRust.Project.Controls"
+    SizeToContent="WidthAndHeight"
+    ResizeMode="NoResize"
+    ShowInTaskbar="False"
+    Title="Visual Rust"
+    Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+    TextOptions.TextFormattingMode="Display"
+    UseLayoutRounding="True" Height="160" Width="435">
+    <Window.Resources>
+        <ResourceDictionary>
+            <Style TargetType="Button">
+                <Setter Property="Width" Value="103"/>
+                <Setter Property="Height" Value="24"/>
+                <Setter Property="Margin" Value="9,9,-3,-3"/>
+                <Setter Property="HorizontalAlignment" Value="Right"/>
+                <Setter Property="DockPanel.Dock" Value="Right"/>
+            </Style>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Window.Content>
+        <DockPanel Margin="12">
+            <DockPanel DockPanel.Dock="Bottom">
+                <Button Click="Cancel">_Cancel</Button>
+                <Button Click="Reload">_Retry</Button>
+                <Button Click="Browse">_Browse...</Button>
+            </DockPanel>
+            <TextBox DockPanel.Dock="Top"
+                Padding="2"
+                Margin="-2,0,-2,0"
+                Background="Transparent"
+                BorderThickness="0"
+                IsReadOnly="True"
+                Text="{Binding FileName, Mode=OneWay}"/>
+            <TextBlock Margin="0,9,0,0" DockPanel.Dock="Top">
+                Cargo manifest could not be loaded due to errors:
+            </TextBlock>
+            <TextBox  DockPanel.Dock="Top"
+                Margin="-2,3,-2,0"
+                IsReadOnly="True"
+                Text="{Binding Errors, Mode=OneWay}"/>
+            <TextBlock Margin="0,9,0,3" DockPanel.Dock="Top">
+                Do you want to pick a different path or reload from the existing one?
+            </TextBlock>
+        </DockPanel>
+    </Window.Content>
+</Window>

--- a/VisualRust.Project/Controls/OpenManifestErrorWindow.xaml
+++ b/VisualRust.Project/Controls/OpenManifestErrorWindow.xaml
@@ -8,6 +8,7 @@
     SizeToContent="WidthAndHeight"
     ResizeMode="NoResize"
     ShowInTaskbar="False"
+    WindowStartupLocation="CenterOwner"
     Title="Visual Rust"
     Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
     TextOptions.TextFormattingMode="Display"
@@ -26,9 +27,9 @@
     <Window.Content>
         <DockPanel Margin="12">
             <DockPanel DockPanel.Dock="Bottom">
-                <Button Click="Cancel">_Cancel</Button>
-                <Button Click="Reload">_Retry</Button>
-                <Button Click="Browse">_Browse...</Button>
+                <Button Click="OnCancel">_Cancel</Button>
+                <Button Click="OnReload">_Retry</Button>
+                <Button Click="OnBrowse">_Browse...</Button>
             </DockPanel>
             <TextBox DockPanel.Dock="Top"
                 Padding="2"
@@ -41,6 +42,7 @@
                 Cargo manifest could not be loaded due to errors:
             </TextBlock>
             <TextBox  DockPanel.Dock="Top"
+                Padding="3"
                 Margin="-2,3,-2,0"
                 IsReadOnly="True"
                 Text="{Binding Errors, Mode=OneWay}"/>

--- a/VisualRust.Project/Controls/OpenManifestErrorWindow.xaml.cs
+++ b/VisualRust.Project/Controls/OpenManifestErrorWindow.xaml.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace VisualRust.Project.Controls
+{
+    public partial class OpenManifestErrorWindow : Window
+    {
+        public OpenManifestErrorWindow()
+        {
+            InitializeComponent();
+        }
+
+        public string FileName { get; private set; }
+        public string Errors { get; private set; }
+        public string NewManifest { get; private set; }
+
+        public OpenManifestErrorWindow(Window owner, string fileName, string[] errors) : this()
+        {
+            Owner = owner;
+            FileName = fileName;
+            Errors = String.Join(Environment.NewLine, errors);
+            DataContext = this;
+        }
+
+        private void Browse(object sender, RoutedEventArgs e)
+        {
+            OpenFileDialog openFile = new OpenFileDialog()
+            {
+                Filter = "TOML files|*.toml|All files|*.*",
+                InitialDirectory = System.IO.Path.GetDirectoryName(FileName),
+            };
+            bool? result = openFile.ShowDialog();
+            if (result == true)
+            {
+                NewManifest = openFile.FileName;
+                DialogResult = true;
+                this.Close();
+            }
+        }
+
+        private void Reload(object sender, RoutedEventArgs e)
+        {
+            DialogResult = null;
+            this.Close();
+        }
+
+        private void Cancel(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            this.Close();
+        }
+    }
+}

--- a/VisualRust.Project/Controls/OpenManifestErrorWindow.xaml.cs
+++ b/VisualRust.Project/Controls/OpenManifestErrorWindow.xaml.cs
@@ -26,6 +26,7 @@ namespace VisualRust.Project.Controls
         public string FileName { get; private set; }
         public string Errors { get; private set; }
         public string NewManifest { get; private set; }
+        public bool Reload { get; private set; }
 
         public OpenManifestErrorWindow(Window owner, string fileName, string[] errors) : this()
         {
@@ -35,7 +36,7 @@ namespace VisualRust.Project.Controls
             DataContext = this;
         }
 
-        private void Browse(object sender, RoutedEventArgs e)
+        private void OnBrowse(object sender, RoutedEventArgs e)
         {
             OpenFileDialog openFile = new OpenFileDialog()
             {
@@ -51,13 +52,14 @@ namespace VisualRust.Project.Controls
             }
         }
 
-        private void Reload(object sender, RoutedEventArgs e)
+        private void OnReload(object sender, RoutedEventArgs e)
         {
-            DialogResult = null;
+            DialogResult = false;
+            Reload = true;
             this.Close();
         }
 
-        private void Cancel(object sender, RoutedEventArgs e)
+        private void OnCancel(object sender, RoutedEventArgs e)
         {
             DialogResult = false;
             this.Close();

--- a/VisualRust.Project/Controls/OutputPage.xaml
+++ b/VisualRust.Project/Controls/OutputPage.xaml
@@ -1,0 +1,47 @@
+﻿<DockPanel x:Class="VisualRust.Project.Controls.OutputPage"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:VisualRust.Project.Controls">
+    <DockPanel.Resources>
+        <DataTemplate x:Key="Library">
+            <StackPanel Orientation="Horizontal">
+                <Canvas Width="16" Height="16">
+                    <Path Data="F1M5,0L5,1 0,1 0,14 16,14 16,1 10.999,1 10.999,0z" Fill="#FFF6F6F6" Height="14" Width="16"/>
+                    <Path Data="F1M8,2L6,2 6,1 8,1z M8,9L6,9 6,8 8,8z M8,11L6,11 6,10 8,10z M5,12L9,12 9,0 5,0z M3,4L1,4 1,2 3,2z M3,9L1,9 1,8 3,8z M3,11L1,11 1,10 3,10z M0,12L4,12 4,1 0,1z M13,4L11,4 11,2 13,2z M13,9L11,9 11,8 13,8z M13,11L11,11 11,10 13,10z M10,12L14,12 14,1 10,1z" Fill="#FF414141" Height="12" Canvas.Left="1" Canvas.Top="1" Width="14"/>
+                    <Path Data="F1M2,1L0,1 0,3 2,3z M2,7L0,7 0,8 2,8z M2,9L0,9 0,10 2,10z M7,0L5,0 5,1 7,1z M7,7L5,7 5,8 7,8z M7,9L5,9 5,10 7,10z M12,1L10,1 10,3 12,3z M12,7L10,7 10,8 12,8z M12,10L10,10 10,9 12,9z" Fill="#FFF0EFF1" Height="10" Canvas.Left="2" Canvas.Top="2" Width="12"/>
+                </Canvas>
+                <TextBlock Text="{Binding TabName, StringFormat={} {0}, Mode=OneTime}"/>
+            </StackPanel>
+        </DataTemplate>
+        <local:ItemTemplateSelector x:Key="ItemTemplateSelector"
+            Binary="{StaticResource Library}"
+            Benchmark="{StaticResource Library}"
+            Example="{StaticResource Library}"
+            Library="{StaticResource Library}"
+            Test="{StaticResource Library}"/>
+    </DockPanel.Resources>
+    <ListBox DockPanel.Dock="Left" ItemTemplateSelector="{StaticResource ItemTemplateSelector}">
+        <!-- https://wilberbeast.com/2011/05/31/compositecollection-binding-problem/ -->
+        <ListBox.Resources>
+            <CollectionViewSource x:Key="LibrariesBridge" Source="{Binding Path=Libraries}" />
+            <CollectionViewSource x:Key="BinariesBridge" Source="{Binding Path=Binaries}" />
+            <CollectionViewSource x:Key="TestsBridge" Source="{Binding Path=Tests}" />
+            <CollectionViewSource x:Key="BenchmarksBridge" Source="{Binding Path=Benchmarks}" />
+            <CollectionViewSource x:Key="ExamplesBridge" Source="{Binding Path=Examples}" />
+        </ListBox.Resources>
+        <ListBox.ItemsSource>
+            <CompositeCollection>
+                <CollectionContainer Collection="{Binding Source={StaticResource LibrariesBridge}}"/>
+                <CollectionContainer Collection="{Binding Source={StaticResource BinariesBridge}}"/>
+                <CollectionContainer Collection="{Binding Source={StaticResource TestsBridge}}"/>
+                <CollectionContainer Collection="{Binding Source={StaticResource BenchmarksBridge}}"/>
+                <CollectionContainer Collection="{Binding Source={StaticResource ExamplesBridge}}"/>
+            </CompositeCollection>
+        </ListBox.ItemsSource>
+    </ListBox>
+    <Grid>
+        
+    </Grid>
+</DockPanel>

--- a/VisualRust.Project/Controls/OutputPage.xaml.cs
+++ b/VisualRust.Project/Controls/OutputPage.xaml.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using VisualRust.Cargo;
+
+namespace VisualRust.Project.Controls
+{
+    public partial class OutputPage : DockPanel
+    {
+        public OutputPage()
+        {
+            InitializeComponent();
+        }
+    }
+
+    public class ItemTemplateSelector: DataTemplateSelector
+    {
+        public DataTemplate Benchmark { get; set; }
+        public DataTemplate Binary { get; set; }
+        public DataTemplate Example { get; set; }
+        public DataTemplate Library { get; set; }
+        public DataTemplate Test { get; set; }
+
+        public override DataTemplate SelectTemplate(object item, DependencyObject container)
+        {
+            IOutputTargetViewModel vm = item as IOutputTargetViewModel;
+            if(item == null)
+                return base.SelectTemplate(item, container);
+            switch (vm.Type)
+            {
+                case OutputTargetType.Benchmark:
+                   return Benchmark;
+                case OutputTargetType.Binary:
+                   return Binary;
+                case OutputTargetType.Example:
+                   return Example;
+                case OutputTargetType.Library:
+                   return Library;
+                case OutputTargetType.Test:
+                   return Test;
+            }
+            return base.SelectTemplate(item, container);
+        }
+    }
+}

--- a/VisualRust.Project/Controls/OutputTargetSectionViewModel.cs
+++ b/VisualRust.Project/Controls/OutputTargetSectionViewModel.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+using VisualRust.Cargo;
+
+namespace VisualRust.Project.Controls
+{
+    public class OutputTargetSectionViewModel: ViewModelBase, IPropertyPageContext
+    {
+        readonly Manifest manifest;
+
+        private IOutputTargetViewModel library;
+        public IOutputTargetViewModel Library
+        {
+            get { return library; }
+            set
+            {
+                Set(ref library, value);
+                Libraries = new IOutputTargetViewModel[] { library };
+            }
+        }
+
+        IOutputTargetViewModel[] libraries;
+        public IOutputTargetViewModel[] Libraries
+        {
+            get { return libraries; }
+            set { Set(ref libraries, value); }
+        }
+
+        private ObservableCollection<IOutputTargetViewModel> binaries;
+        public ObservableCollection<IOutputTargetViewModel> Binaries
+        {
+            get { return binaries; }
+            set { Set(ref binaries, value); }
+        }
+
+        private ObservableCollection<IOutputTargetViewModel> benchmarks;
+        public ObservableCollection<IOutputTargetViewModel> Benchmarks
+        {
+            get { return benchmarks; }
+            set { Set(ref benchmarks, value); }
+        }
+
+        private ObservableCollection<IOutputTargetViewModel> tests;
+        public ObservableCollection<IOutputTargetViewModel> Tests
+        {
+            get { return tests; }
+            set { Set(ref tests, value); }
+        }
+
+        private ObservableCollection<IOutputTargetViewModel> examples;
+        public ObservableCollection<IOutputTargetViewModel> Examples
+        {
+            get { return examples; }
+            set { Set(ref examples, value); }
+        }
+
+        public OutputTargetSectionViewModel(Manifest m)
+        {
+            this.manifest = m;
+            Load();
+        }
+
+        private bool isDirty;
+        public bool IsDirty
+        {
+            get { return isDirty; }
+            set
+            {
+                isDirty = value;
+                var temp = DirtyChanged;
+                if(temp != null)
+                    temp(null, null);
+            }
+        }
+
+        public event EventHandler DirtyChanged;
+
+        public void Apply()
+        {
+            IsDirty = false;
+            throw new NotImplementedException();
+        }
+
+        private void Load()
+        {
+            var lookup = manifest.OutputTargets.ToLookup(t => t.Type);
+            var rawLibrary = lookup[OutputTargetType.Library].FirstOrDefault();
+            if(rawLibrary != null)
+                Library = new OutputTargetViewModel(rawLibrary);
+            else 
+                Library = new LibraryAutoOutputTargetViewModel(manifest);
+            binaries =  LoadTargets(lookup[OutputTargetType.Binary], () => new BinaryAutoOutputTargetViewModel(manifest));
+            benchmarks =  LoadTargets(lookup[OutputTargetType.Benchmark], () => new BenchmarkAutoOutputTargetViewModel(manifest));
+            tests =  LoadTargets(lookup[OutputTargetType.Test], () => new TestAutoOutputTargetViewModel(manifest));
+            examples =  LoadTargets(lookup[OutputTargetType.Example], () => new ExampleAutoOutputTargetViewModel(manifest));
+        }
+
+        static ObservableCollection<IOutputTargetViewModel> LoadTargets(IEnumerable<OutputTarget> targets, Func<IOutputTargetViewModel> ctor)
+        {
+            List<OutputTargetViewModel> vms = targets.Select(t => new OutputTargetViewModel(t)).ToList();
+            if(vms.Count == 0)
+                return new ObservableCollection<IOutputTargetViewModel> { ctor() };
+            return new ObservableCollection<IOutputTargetViewModel>();
+        }
+    }
+}

--- a/VisualRust.Project/Controls/OutputTargetViewModel.cs
+++ b/VisualRust.Project/Controls/OutputTargetViewModel.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using VisualRust.Cargo;
+
+namespace VisualRust.Project.Controls
+{
+    public class OutputTargetViewModel : ViewModelBase, IOutputTargetViewModel
+    {
+        public OutputTargetType Type { get; private set; }
+
+        public string TabName { get { return this.Name; } }
+
+        private string name;
+        public string Name
+        {
+            get { return name; }
+            set { Set(ref name, value); }
+        }
+        
+        private string path;
+        public string Path
+        {
+            get { return path; }
+            set { Set(ref path, value); }
+        }
+        
+        private bool test;
+        public bool Test
+        {
+            get { return test; }
+            set { Set(ref test, value); }
+        }
+        
+        private bool doctest;
+        public bool Doctest
+        {
+            get { return doctest; }
+            set { Set(ref doctest, value); }
+        }
+        
+        private bool bench;
+        public bool Bench
+        {
+            get { return bench; }
+            set { Set(ref bench, value); }
+        }
+        
+        private bool doc;
+        public bool Doc
+        {
+            get { return doc; }
+            set { Set(ref doc, value); }
+        }
+        
+        private bool plugin;
+        public bool Plugin
+        {
+            get { return plugin; }
+            set { Set(ref plugin, value); }
+        }
+
+        private bool harness;
+        public bool Harness
+        {
+            get { return harness; }
+            set { Set(ref harness, value); }
+        }
+
+        public bool IsReadOnly { get { return false; } }
+
+        public OutputTargetViewModel(OutputTarget t)
+        {
+            Type = t.Type;
+            name = t.Name;
+            path = t.Path;
+            test = t.Test;
+            doctest = t.Doctest;
+            bench = t.Bench;
+            doc = t.Doc;
+            plugin = t.Plugin;
+            harness = t.Harness;
+        }
+    }
+}

--- a/VisualRust.Project/Controls/TestAutoOutputTargetViewModel.cs
+++ b/VisualRust.Project/Controls/TestAutoOutputTargetViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using VisualRust.Cargo;
+
+namespace VisualRust.Project.Controls
+{
+    internal class TestAutoOutputTargetViewModel : AutoOutputTargetViewModel
+    {
+        public TestAutoOutputTargetViewModel(Manifest m) : base(m)
+        {
+        }
+
+        public override OutputTargetType Type { get { return OutputTargetType.Test; } }
+        public override string Name { get { return AutoDetect; } }
+        public override string Path { get { return @"tests\*.rs"; } }
+    }
+}

--- a/VisualRust.Project/Controls/ViewModelBase.cs
+++ b/VisualRust.Project/Controls/ViewModelBase.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace VisualRust
+{
+    public class ViewModelBase : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected bool Set<T>(ref T field, T value, [CallerMemberName] string property = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+            var oldValue = field;
+            field = value;
+            RaisePropertyChanged(property);
+            return true;
+        }
+
+        private void RaisePropertyChanged(string property)
+        {
+            var handler = PropertyChanged;
+            if (handler != null)
+            {
+                handler(this, new PropertyChangedEventArgs(property));
+            }
+        }
+    }
+}

--- a/VisualRust.Project/ManifestLoadResult.cs
+++ b/VisualRust.Project/ManifestLoadResult.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VisualRust.Cargo;
+
+namespace VisualRust.Project
+{
+    class ManifestLoadResult
+    {
+        public bool Cancel { get; private set; }
+        public Manifest Manifest { get; private set; }
+
+        private ManifestLoadResult() { }
+
+        public static ManifestLoadResult CreateCancel()
+        {
+            return new ManifestLoadResult
+            {
+                Cancel = true
+            };
+        }
+
+        public static ManifestLoadResult CreateSuccess(Manifest m)
+        {
+            return new ManifestLoadResult
+            {
+                Manifest = m
+            };
+        }
+    }
+}

--- a/VisualRust.Project/RustProjectNode.cs
+++ b/VisualRust.Project/RustProjectNode.cs
@@ -75,6 +75,7 @@ namespace VisualRust.Project
         private bool containsEntryPoint;
         public UserProjectConfig UserConfig { get; private set; }
         internal ModuleTracker ModuleTracker { get; private set; }
+        internal Manifest Manifest { get; private set; }
 
         public RustProjectNode(CommonProjectPackage package)
             : base(package, Utilities.GetImageList(new System.Drawing.Bitmap(typeof(RustProjectNode).Assembly.GetManifestResourceStream("VisualRust.Project.Resources.IconList.bmp"))))
@@ -87,11 +88,11 @@ namespace VisualRust.Project
 
         void ReloadOnOutputChange(object sender, ProjectPropertyChangedArgs e)
         {
-            if(String.Equals(e.PropertyName, "OutputType", StringComparison.OrdinalIgnoreCase)
+            if (String.Equals(e.PropertyName, "OutputType", StringComparison.OrdinalIgnoreCase)
                 && !String.Equals(e.OldValue, e.NewValue, StringComparison.OrdinalIgnoreCase))
             {
-                TrackedFileNode crateNode =  this.GetCrateFileNode(e.OldValue);
-                if(crateNode != null)
+                TrackedFileNode crateNode = this.GetCrateFileNode(e.OldValue);
+                if (crateNode != null)
                     crateNode.IsEntryPoint = false;
                 int temp;
                 this.ReloadCore(out temp);
@@ -154,9 +155,13 @@ namespace VisualRust.Project
 
         protected void ReloadCore(out int canceled)
         {
-            LoadManifest(out canceled);
-            if(canceled != 0)
+            ManifestLoadResult manifestResult = LoadManifest();
+            if (manifestResult.Cancel)
+            {
+                canceled = 1;
                 return;
+            }
+            this.Manifest = manifestResult.Manifest;
             this.UserConfig = new UserProjectConfig(this);
             string outputType = GetProjectProperty(ProjectFileConstants.OutputType, true);
             string entryPoint = GetCrateFileNodePath(outputType);
@@ -179,35 +184,61 @@ namespace VisualRust.Project
             }
         }
 
-        void LoadManifest(out int canceled)
+        ManifestLoadResult LoadManifest()
         {
             string manifestPath = this.BuildProject.GetPropertyValue("ManifestPath");
             string manifestPathFull = Path.GetFullPath(Path.Combine(this.ProjectFolder, manifestPath));
-            string manifestContent = "";
+            string manifestContent;
             try
             {
-                 manifestContent = File.ReadAllText(manifestPathFull);
+                manifestContent = File.ReadAllText(manifestPathFull);
             }
-            catch(IOException ex)
+            catch (IOException ex)
             {
                 var window = new Controls.OpenManifestErrorWindow(System.Windows.Application.Current.MainWindow, manifestPathFull, new string[] { ex.Message });
                 bool? result = window.ShowDialog();
-                if(result == null || result == false)
+                if (result == false)
                 {
-                    canceled = 1;
-                    return;
+                    if(window.Reload)
+                        return LoadManifest();
+                    return ManifestLoadResult.CreateCancel();
+                }
+                else
+                {
+                    this.BuildProject.SetProperty("ManifestPath", CommonUtils.GetRelativeFilePath(this.ProjectFolder, manifestPathFull));
+                    return LoadManifest();
                 }
             }
-            canceled = 0;
+            ManifestErrors errors;
+            Manifest manifest = Manifest.TryCreate(manifestContent, out errors);
+            if (manifest == null)
+            {
+                string[] parseError = String.IsNullOrEmpty(errors.ParseError) ? new string[0] : new[] { errors.ParseError };
+                IEnumerable<string> errorsText = parseError.Union(errors.LoadErrors.Select(e => e.ToString()));
+                var window = new Controls.OpenManifestErrorWindow(System.Windows.Application.Current.MainWindow, manifestPathFull, errorsText.ToArray());
+                bool? result = window.ShowDialog();
+                if (result == false)
+                {
+                    if(window.Reload)
+                        return LoadManifest();
+                    return ManifestLoadResult.CreateCancel();
+                }
+                else
+                {
+                    this.BuildProject.SetProperty("ManifestPath", CommonUtils.GetRelativeFilePath(this.ProjectFolder, manifestPathFull));
+                    return LoadManifest();
+                }
+            }
+            return ManifestLoadResult.CreateSuccess(manifest);
         }
 
         private void MarkEntryPointFolders(string outputType)
         {
             HierarchyNode node = GetCrateFileNode(outputType);
-            while(true)
+            while (true)
             {
                 node = node.Parent;
-                if(!(node is RustFolderNode))
+                if (!(node is RustFolderNode))
                     break;
                 ((RustFolderNode)node).IsEntryPoint = true;
             }
@@ -230,7 +261,7 @@ namespace VisualRust.Project
             else
             {
                 HashSet<string> children = ModuleTracker.AddRootModuleIncremental(node.Url);
-                foreach(string child in children)
+                foreach (string child in children)
                 {
                     HierarchyNode parent = this.CreateFolderNodes(Path.GetDirectoryName(child), false);
                     parent.AddChild(CreateUntrackedNode(child));
@@ -269,7 +300,7 @@ namespace VisualRust.Project
         protected override HierarchyNode AddIndependentFileNode(Microsoft.Build.Evaluation.ProjectItem item, HierarchyNode parent)
         {
             var node = (TrackedFileNode)base.AddIndependentFileNode(item, parent);
-            if(node.GetModuleTracking())
+            if (node.GetModuleTracking())
             {
                 if (node.Url.Equals(ModuleTracker.EntryPoint, StringComparison.InvariantCultureIgnoreCase))
                 {
@@ -332,7 +363,7 @@ namespace VisualRust.Project
         internal void ReparseFileNode(BaseFileNode n)
         {
             var diff = ModuleTracker.Reparse(n.Url);
-            foreach(string mod in diff.Removed)
+            foreach (string mod in diff.Removed)
             {
                 TreeOperations.RemoveSubnodeFromHierarchy(this, mod, false);
             }
@@ -346,7 +377,7 @@ namespace VisualRust.Project
         public override int SaveItem(VSSAVEFLAGS saveFlag, string silentSaveAsName, uint itemid, IntPtr docData, out int cancelled)
         {
             BaseFileNode node = this.NodeFromItemId(itemid) as BaseFileNode;
-            if(node != null)
+            if (node != null)
             {
                 int result = base.SaveItem(saveFlag, silentSaveAsName, itemid, docData, out cancelled);
                 if (result == VSConstants.S_OK)
@@ -411,14 +442,14 @@ namespace VisualRust.Project
             return VSConstants.S_OK;
         }
 
-#region Disable "Add references..."
+        #region Disable "Add references..."
         protected override ReferenceContainerNode CreateReferenceContainerNode()
         {
             return null;
         }
 
         internal override int QueryStatusOnNode(Guid cmdGroup, uint cmd, IntPtr pCmdText, ref QueryStatusResult result)
-        { 
+        {
             if (cmdGroup == VsMenus.guidStandardCommandSet2K && (VsCommands2K)cmd == VsCommands2K.ADDCOMPONENTS
                 || cmdGroup == VSConstants.CMDSETID.StandardCommandSet12_guid && (VSConstants.VSStd12CmdID)cmd == VSConstants.VSStd12CmdID.AddReferenceProjectOnly)
             {
@@ -442,7 +473,7 @@ namespace VisualRust.Project
         {
             return VSConstants.E_NOTIMPL;
         }
-#endregion
+        #endregion
 
         // This is OK, because this function is only called by
         // ProjectGuid getter, which we override anyway
@@ -450,7 +481,7 @@ namespace VisualRust.Project
         {
             throw new InvalidOperationException();
         }
-        
+
         // This is OK, because this function is only called by
         // GetSpecificEditorType(...), which we override anyway
         public override Type GetEditorFactoryType()

--- a/VisualRust.Project/RustProjectNode.cs
+++ b/VisualRust.Project/RustProjectNode.cs
@@ -213,9 +213,7 @@ namespace VisualRust.Project
             Manifest manifest = Manifest.TryCreate(manifestContent, out errors);
             if (manifest == null)
             {
-                string[] parseError = String.IsNullOrEmpty(errors.ParseError) ? new string[0] : new[] { errors.ParseError };
-                IEnumerable<string> errorsText = parseError.Union(errors.LoadErrors.Select(e => e.ToString()));
-                var window = new Controls.OpenManifestErrorWindow(System.Windows.Application.Current.MainWindow, manifestPathFull, errorsText.ToArray());
+                var window = new Controls.OpenManifestErrorWindow(System.Windows.Application.Current.MainWindow, manifestPathFull, errors.GetErrors());
                 bool? result = window.ShowDialog();
                 if (result == false)
                 {
@@ -537,6 +535,7 @@ namespace VisualRust.Project
         {
             return new[] {
                 new Guid(Constants.ApplicationPropertyPage),
+                new Guid(Constants.TargetOutputsPage),
             };
         }
     }

--- a/VisualRust.Project/RustProjectNodeProperties.cs
+++ b/VisualRust.Project/RustProjectNodeProperties.cs
@@ -7,12 +7,15 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using VisualRust.Cargo;
 
 namespace VisualRust.Project
 {
     [CLSCompliant(false), ComVisible(true)]
     public class RustProjectNodeProperties : ProjectNodeProperties
     {
+        public Manifest Manifest { get { return ((RustProjectNode)this.Node).Manifest; } }
+
         internal RustProjectNodeProperties(CommonProjectNode node)
             : base(node)
         { }

--- a/VisualRust.Project/VisualRust.Project.csproj
+++ b/VisualRust.Project/VisualRust.Project.csproj
@@ -130,10 +130,12 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="UIAutomationTypes" />
@@ -162,6 +164,9 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Build.tt</DependentUpon>
+    </Compile>
+    <Compile Include="Controls\OpenManifestErrorWindow.xaml.cs">
+      <DependentUpon>OpenManifestErrorWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Launcher\GnuDebugLauncher.cs" />
     <Compile Include="Launcher\IRustProjectLauncher.cs" />
@@ -228,6 +233,10 @@
       <Project>{6D2688FE-6FD8-44A8-B96A-6037457F72A7}</Project>
       <Name>MIDebugEngine</Name>
     </ProjectReference>
+    <ProjectReference Include="..\VisualRust.Cargo\VisualRust.Cargo.csproj">
+      <Project>{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}</Project>
+      <Name>VisualRust.Cargo</Name>
+    </ProjectReference>
     <ProjectReference Include="..\VisualRust.Shared\VisualRust.Shared.csproj">
       <Project>{b99cc9eb-90f2-4040-9e66-418cc7042153}</Project>
       <Name>VisualRust.Shared</Name>
@@ -272,6 +281,12 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Debug.cs</LastGenOutput>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="Controls\OpenManifestErrorWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/VisualRust.Project/VisualRust.Project.csproj
+++ b/VisualRust.Project/VisualRust.Project.csproj
@@ -165,9 +165,23 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Build.tt</DependentUpon>
     </Compile>
+    <Compile Include="Controls\AutoOutputTargetViewModel.cs" />
+    <Compile Include="Controls\BenchmarkAutoOutputTargetViewModel.cs" />
+    <Compile Include="Controls\BinaryAutoOutputTargetViewModel.cs" />
+    <Compile Include="Controls\ExampleAutoOutputTargetViewModel.cs" />
+    <Compile Include="Controls\IOutputTargetViewModel.cs" />
+    <Compile Include="Controls\IPropertyPageContext.cs" />
+    <Compile Include="Controls\LibraryAutoOutputTargetViewModel.cs" />
     <Compile Include="Controls\OpenManifestErrorWindow.xaml.cs">
       <DependentUpon>OpenManifestErrorWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\OutputPage.xaml.cs">
+      <DependentUpon>OutputPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Controls\OutputTargetSectionViewModel.cs" />
+    <Compile Include="Controls\OutputTargetViewModel.cs" />
+    <Compile Include="Controls\TestAutoOutputTargetViewModel.cs" />
+    <Compile Include="Controls\ViewModelBase.cs" />
     <Compile Include="Launcher\GnuDebugLauncher.cs" />
     <Compile Include="Launcher\IRustProjectLauncher.cs" />
     <Compile Include="Launcher\MsvcDebugLauncher.cs" />
@@ -285,6 +299,10 @@
   </ItemGroup>
   <ItemGroup>
     <Page Include="Controls\OpenManifestErrorWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\OutputPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/VisualRust.Project/VisualRust.Project.csproj
+++ b/VisualRust.Project/VisualRust.Project.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Launcher\MsvcDebugLauncher.cs" />
     <Compile Include="Launcher\ReleaseLauncher.cs" />
     <Compile Include="Launcher\LauncherEnviroment.cs" />
+    <Compile Include="ManifestLoadResult.cs" />
     <Compile Include="RustProjectLauncher.cs" />
     <Compile Include="EnvironmentPath.cs" />
     <Compile Include="FolderNode.cs" />

--- a/VisualRust.Test/Cargo/ManifestTests.cs
+++ b/VisualRust.Test/Cargo/ManifestTests.cs
@@ -157,19 +157,19 @@ namespace VisualRust.Test.Cargo
                   name = ""bin2""
                   path = ""bin2.rs""",
                 out temp);
-            OutputTarget t1 = GetOutputTarget(m.OutputTargets, "bench", "bench1");
+            OutputTarget t1 = GetOutputTarget(m.OutputTargets, OutputTargetType.Benchmark, "bench1");
             Assert.AreEqual("bench1.rs", t1.Path);
-            OutputTarget t2 = GetOutputTarget(m.OutputTargets, "lib", "bar");
+            OutputTarget t2 = GetOutputTarget(m.OutputTargets, OutputTargetType.Library, "bar");
             Assert.AreEqual("src.rs", t2.Path);
-            OutputTarget t3 = GetOutputTarget(m.OutputTargets, "bin", "bin1");
+            OutputTarget t3 = GetOutputTarget(m.OutputTargets, OutputTargetType.Binary, "bin1");
             Assert.AreEqual("bin1.rs", t3.Path);
-            OutputTarget t4 = GetOutputTarget(m.OutputTargets, "bench", "bench2");
+            OutputTarget t4 = GetOutputTarget(m.OutputTargets, OutputTargetType.Benchmark, "bench2");
             Assert.AreEqual("bench2.rs", t4.Path);
-            OutputTarget t5 = GetOutputTarget(m.OutputTargets, "bin", "bin2");
+            OutputTarget t5 = GetOutputTarget(m.OutputTargets, OutputTargetType.Binary, "bin2");
             Assert.AreEqual("bin2.rs", t5.Path);
         }
 
-        static OutputTarget GetOutputTarget(OutputTarget[] targets, string type, string name)
+        static OutputTarget GetOutputTarget(OutputTarget[] targets, OutputTargetType type, string name)
         {
             return targets.First(t => t.Type == type && t.Name == name);
         }

--- a/VisualRust.Test/Project/Controls/OutputTargetSectionViewModelTests.cs
+++ b/VisualRust.Test/Project/Controls/OutputTargetSectionViewModelTests.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VisualRust.Cargo;
+using VisualRust.Project.Controls;
+
+namespace VisualRust.Test.Project.Controls
+{
+    class OutputTargetSectionViewModelTests
+    {
+        [Test]
+        public void ShouldExposeDefaultTargets()
+        {
+            var manifest = Manifest.CreateFake("foo", null);
+            var vm = new OutputTargetSectionViewModel(manifest);
+            Assert.NotNull(vm.Library);
+            Assert.AreEqual(1, vm.Binaries.Count);
+            Assert.AreEqual(1, vm.Benchmarks.Count);
+            Assert.AreEqual(1, vm.Tests.Count);
+            Assert.AreEqual(1, vm.Examples.Count);
+        }
+    }
+}

--- a/VisualRust.Test/VisualRust.Test.csproj
+++ b/VisualRust.Test/VisualRust.Test.csproj
@@ -54,6 +54,7 @@
     <EmbeddedResource Include="Internal\CircularNested\in\foo.rs" />
     <EmbeddedResource Include="Internal\CircularNested\main.rs" />
     <Compile Include="Cargo\ManifestTests.cs" />
+    <Compile Include="Project\Controls\OutputTargetSectionViewModelTests.cs" />
     <Compile Include="Project\ModuleImportTests.cs" />
     <Compile Include="Project\ModuleParserTests.cs" />
     <Compile Include="Project\ModuleTrackerTests.cs" />

--- a/VisualRust/ProjectForms/TargetOutputsPropertyPage.cs
+++ b/VisualRust/ProjectForms/TargetOutputsPropertyPage.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using VisualRust.Project.Controls;
+
+namespace VisualRust.Project.Forms
+{
+    [ComVisible(true)]
+    [System.Runtime.InteropServices.Guid(Constants.TargetOutputsPage)]
+    public class TargetOutputsPropertyPage : WpfPropertyPage
+    {
+        public override string Name { get { return "Output Targets"; } }
+        protected override FrameworkElement CreateControl()
+        {
+            return new OutputPage();
+        }
+
+        protected override IPropertyPageContext CreateDataContext()
+        {
+            return new OutputTargetSectionViewModel(this.Config.Manifest);
+        }
+    }
+}

--- a/VisualRust/ProjectForms/WpfPropertyPage.cs
+++ b/VisualRust/ProjectForms/WpfPropertyPage.cs
@@ -1,0 +1,143 @@
+﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudioTools.Project;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using System.Windows.Media;
+using VisualRust.Project.Controls;
+
+namespace VisualRust.Project.Forms
+{
+    [ComVisible(true)]
+    public abstract class WpfPropertyPage : IPropertyPage
+    {
+        IPropertyPageContext data;
+        HwndSource source;
+        FrameworkElement control;
+
+        protected IPropertyPageSite Site { get; private set; }
+        public abstract string Name { get; }
+        internal RustProjectNodeProperties Config { get; private set; }
+
+        public void Activate(IntPtr hWndParent, RECT[] pRect, int bModal)
+        {
+            int width = pRect[0].right - pRect[0].left;
+            int height = pRect[0].bottom - pRect[0].top;
+            source = new HwndSource(0, 0x54000000, 0, pRect[0].left, pRect[0].top, width, height, "", hWndParent);
+            control = CreateControl();
+            control.DataContext = data;
+            source.RootVisual = control;
+        }
+
+        abstract protected FrameworkElement CreateControl();
+        abstract protected IPropertyPageContext CreateDataContext();
+
+        public int Apply()
+        {
+            try
+            {
+                data.Apply();
+                return VSConstants.S_OK;
+            }
+            catch (Exception e)
+            {
+                return Marshal.GetHRForException(e);
+            }
+        }
+
+        public void Deactivate()
+        {
+            source.Dispose();
+        }
+
+        public void GetPageInfo(PROPPAGEINFO[] pPageInfo)
+        {
+            Utilities.ArgumentNotNull("pPageInfo", pPageInfo);
+
+            PROPPAGEINFO info = new PROPPAGEINFO();
+
+            info.cb = (uint)Marshal.SizeOf(typeof(PROPPAGEINFO));
+            info.dwHelpContext = 0;
+            info.pszDocString = null;
+            info.pszHelpFile = null;
+            info.pszTitle = Name;
+            if (source == null)
+            {
+                info.SIZE.cx = 0;
+                info.SIZE.cy = 0;
+            }
+            else
+            {
+                RECT[] pRect;
+                NativeMethods.GetWindowRect(source.Handle, out pRect);
+                int width = pRect[0].right - pRect[0].left;
+                int height = pRect[0].bottom - pRect[0].top;
+                info.SIZE.cx = width;
+                info.SIZE.cx = height;
+            }
+            pPageInfo[0] = info;
+        }
+
+        public void Help(string pszHelpDir)
+        {
+        }
+
+        public void Move(RECT[] pRect)
+        {
+            int width = pRect[0].right - pRect[0].left;
+            int height = pRect[0].bottom - pRect[0].top;
+            NativeMethods.SetWindowPos(this.source.Handle, IntPtr.Zero, pRect[0].left, pRect[0].top, width, height, 0x44);
+        }
+
+        public void SetObjects(uint cObjects, object[] ppunk)
+        {
+            if (ppunk == null)
+            {
+                return;
+            }
+
+            if (cObjects > 0)
+            {
+                RustProjectNodeProperties ctx = ppunk[0] as RustProjectNodeProperties;
+                if(ctx != null)
+                {
+                    this.Config = ctx;
+                    data = CreateDataContext();
+                    data.DirtyChanged += (_, __) => Site.OnStatusChange((uint)(data.IsDirty ? PropPageStatus.Dirty : PropPageStatus.Clean));
+                }
+            }
+        }
+
+        public void SetPageSite(IPropertyPageSite pPageSite)
+        {
+            Site = pPageSite;
+        }
+
+        public void Show(uint nCmdShow)
+        {
+            if (nCmdShow == NativeMethods.SW_SHOW || nCmdShow == NativeMethods.SW_SHOWNORMAL)
+                control.Visibility = Visibility.Visible;
+            if (nCmdShow == NativeMethods.SW_HIDE)
+                control.Visibility = Visibility.Collapsed;
+        }
+
+        public int TranslateAccelerator(Microsoft.VisualStudio.OLE.Interop.MSG[] pMsg)
+        {
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int IsPageDirty()
+        {
+            if(data == null)
+                return VSConstants.S_FALSE;
+            return data.IsDirty ? VSConstants.S_OK : VSConstants.S_FALSE;
+        }
+    }
+}

--- a/VisualRust/VisualRust.csproj
+++ b/VisualRust/VisualRust.csproj
@@ -227,6 +227,8 @@
     <Compile Include="Forms\DebuggingOptionsPageControl.Designer.cs">
       <DependentUpon>DebuggingOptionsPageControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="ProjectForms\TargetOutputsPropertyPage.cs" />
+    <Compile Include="ProjectForms\WpfPropertyPage.cs" />
     <Compile Include="ProjectForms\GeneralPropertyPage.cs" />
     <Compile Include="Forms\RustOptionsPageControl.cs">
       <SubType>UserControl</SubType>
@@ -334,6 +336,10 @@
     <ProjectReference Include="..\RustLexer\RustLexer.csproj">
       <Project>{e983e989-f83a-4643-896a-ad496bf647d0}</Project>
       <Name>RustLexer</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\VisualRust.Cargo\VisualRust.Cargo.csproj">
+      <Project>{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}</Project>
+      <Name>VisualRust.Cargo</Name>
     </ProjectReference>
     <ProjectReference Include="..\VisualRust.Templates\VisualRust.Templates.csproj">
       <Project>{59D94B96-1AF7-46F2-8790-AAB6DFAE8D9A}</Project>

--- a/VisualRust/VisualRustPackage.cs
+++ b/VisualRust/VisualRustPackage.cs
@@ -64,6 +64,7 @@ namespace VisualRust
     [ProvideObject(typeof(Project.Forms.ApplicationPropertyPage))]
     [ProvideObject(typeof(Project.Forms.BuildPropertyPage))]
     [ProvideObject(typeof(Project.Forms.DebugPropertyPage))]
+    [ProvideObject(typeof(Project.Forms.TargetOutputsPropertyPage))]
     [ProvideOptionPage(typeof(RustOptionsPage), "Visual Rust", "General", 110, 113, true)]
     [ProvideOptionPage(typeof(DebuggingOptionsPage), "Visual Rust", "Debugging", 110, 114, true)]
     [ProvideProfile(typeof(RustOptionsPage), "Visual Rust", "General", 110, 113, true)]

--- a/vist_toml/src/capi.rs
+++ b/vist_toml/src/capi.rs
@@ -3,10 +3,12 @@ use std::ptr;
 use std::slice;
 
 use toml_document::{Document, ParserError};
-use winapi::{BOOL, INT32};
+use winapi::INT32;
 
 use super::*;
 use panic::*;
+
+type Boolean = u8;
 
 #[repr(C)]
 pub struct ParseResult {
@@ -161,27 +163,29 @@ impl MultiQueryResult<OwnedSlice<OutputTargetFFI>> {
 
 #[repr(C)]
 pub struct OutputTargetFFI {
+    kind: OwnedSlice<u8>,
     name: OwnedSlice<u8>,
     path: OwnedSlice<u8>,
-    test: BOOL,
-    doctest: BOOL,
-    bench: BOOL,
-    doc: BOOL,
-    plugin: BOOL,
-    harness: BOOL
+    test: Boolean,
+    doctest: Boolean,
+    bench: Boolean,
+    doc: Boolean,
+    plugin: Boolean,
+    harness: Boolean
 }
 
 impl OutputTargetFFI {
     fn from(t: &OutputTarget) -> OutputTargetFFI {
         OutputTargetFFI {
+            kind: OwnedSlice::from_str(t.kind),
             name: OwnedSlice::from_str_opt(t.name),
             path: OwnedSlice::from_str_opt(t.path),
-            test: t.test as BOOL,
-            doctest: t.doctest as BOOL,
-            bench: t.bench as BOOL,
-            doc: t.doc as BOOL,
-            plugin: t.plugin as BOOL,
-            harness: t.harness as BOOL,
+            test: t.test as Boolean,
+            doctest: t.doctest as Boolean,
+            bench: t.bench as Boolean,
+            doc: t.doc as Boolean,
+            plugin: t.plugin as Boolean,
+            harness: t.harness as Boolean,
         }
     }
 }
@@ -223,6 +227,11 @@ pub extern "C" fn free_strbox_array(s: OwnedSlice<OwnedSlice<u8>>) {
 
 #[no_mangle]
 pub extern "C" fn free_dependencies_result(r: MultiQueryResult<OwnedSlice<RawDependency>>) {
+    drop(r)
+}
+
+#[no_mangle]
+pub extern "C" fn free_output_targets_result(r: MultiQueryResult<OwnedSlice<OutputTargetFFI>>) {
     drop(r)
 }
 

--- a/vist_toml/src/lib.rs
+++ b/vist_toml/src/lib.rs
@@ -376,6 +376,7 @@ pub struct PathError {
 }
 
 pub struct OutputTarget<'a> {
+    kind: &'static str,
     name: Option<&'a str>,
     path: Option<&'a str>,
     test: bool,
@@ -389,6 +390,7 @@ pub struct OutputTarget<'a> {
 impl<'a> OutputTarget<'a> {
     fn default() -> OutputTarget<'a> {
         OutputTarget {
+            kind: "",
             name: None,
             path: None,
             test: true,
@@ -402,6 +404,7 @@ impl<'a> OutputTarget<'a> {
 
     fn bin() -> OutputTarget<'a> {
         OutputTarget {
+            kind: "bin",
             doc: true,
             ..OutputTarget::default()
         }
@@ -409,6 +412,7 @@ impl<'a> OutputTarget<'a> {
 
     fn lib() -> OutputTarget<'a> {
         OutputTarget {
+            kind: "lib",
             doctest: true,
             doc: true,
             ..OutputTarget::default()
@@ -417,6 +421,7 @@ impl<'a> OutputTarget<'a> {
 
     fn bench() -> OutputTarget<'a> {
         OutputTarget {
+            kind: "bench",
             test: false,
             ..OutputTarget::default()
         }
@@ -424,6 +429,7 @@ impl<'a> OutputTarget<'a> {
 
     fn test() -> OutputTarget<'a> {
         OutputTarget {
+            kind: "test",
             bench: false,
             ..OutputTarget::default()
         }
@@ -431,6 +437,7 @@ impl<'a> OutputTarget<'a> {
 
     fn example() -> OutputTarget<'a> {
         OutputTarget {
+            kind: "example",
             bench: false,
             ..OutputTarget::default()
         }


### PR DESCRIPTION
This is far from finished, but most of the dirty work (parsing and interoping tables from manifest,  exposing WPF properties page, wrapping ViewModels) is done.