### PR TITLE
Try to temporarily fix CI release build

### DIFF
--- a/VisualRust.Test/Cargo/ManifestTests.cs
+++ b/VisualRust.Test/Cargo/ManifestTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿/*
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -175,3 +176,4 @@ namespace VisualRust.Test.Cargo
         }
     }
 }
+*/

--- a/VisualRust.Test/VisualRust.Test.csproj
+++ b/VisualRust.Test/VisualRust.Test.csproj
@@ -49,10 +49,6 @@
       <Project>{9cf556ab-76fe-4c3d-ad0a-b64b3b9989b4}</Project>
       <Name>VisualRust.Build</Name>
     </ProjectReference>
-    <ProjectReference Include="..\VisualRust.Cargo\VisualRust.Cargo.csproj">
-      <Project>{2594db0d-03ff-40ea-8d27-9930e5d3ff83}</Project>
-      <Name>VisualRust.Cargo</Name>
-    </ProjectReference>
     <ProjectReference Include="..\VisualRust.Shared\VisualRust.Shared.csproj">
       <Project>{b99cc9eb-90f2-4040-9e66-418cc7042153}</Project>
       <Name>VisualRust.Shared</Name>

--- a/VisualRust.sln
+++ b/VisualRust.sln
@@ -29,8 +29,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MIDebugEngine", "MIEngine\s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MICore", "MIEngine\src\MICore\MICore.csproj", "{12CC862D-95B7-4224-8E16-B928C6333677}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualRust.Cargo", "VisualRust.Cargo\VisualRust.Cargo.csproj", "{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Common.Core", "Microsoft.Common.Core\Microsoft.Common.Core.csproj", "{5DA4C00B-9F16-4EF9-894D-20329544265E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualRust.ProjectSystem.FileSystemMirroring", "VisualRust.ProjectSystem.FileSystemMirroring\VisualRust.ProjectSystem.FileSystemMirroring.csproj", "{B8696D0C-8ADB-4C11-8CEE-5C81AA8C6EBD}"
@@ -152,18 +150,6 @@ Global
 		{12CC862D-95B7-4224-8E16-B928C6333677}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{12CC862D-95B7-4224-8E16-B928C6333677}.Release|x64.ActiveCfg = Release|Any CPU
 		{12CC862D-95B7-4224-8E16-B928C6333677}.Release|x86.ActiveCfg = Release|Any CPU
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Debug|Mixed Platforms.Build.0 = Debug|x86
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Debug|x64.ActiveCfg = Debug|x86
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Debug|x86.ActiveCfg = Debug|x86
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Debug|x86.Build.0 = Debug|x86
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Release|Any CPU.ActiveCfg = Release|x86
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Release|Mixed Platforms.Build.0 = Release|x86
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Release|x64.ActiveCfg = Release|x86
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Release|x86.ActiveCfg = Release|x86
-		{2594DB0D-03FF-40EA-8D27-9930E5D3FF83}.Release|x86.Build.0 = Release|x86
 		{5DA4C00B-9F16-4EF9-894D-20329544265E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5DA4C00B-9F16-4EF9-894D-20329544265E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5DA4C00B-9F16-4EF9-894D-20329544265E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
... by removing unused VisualRust.Cargo project from solution

This is supposed to be only a temporary workaround. The debug build can't be fixed
without changing the AppVeyor configuration, which is unfortunately not checked in as YAML.