### PR TITLE
Added UTF8 encoding to process start information for rust tool

### DIFF
--- a/VisualRust.Build/CargoBuild.cs
+++ b/VisualRust.Build/CargoBuild.cs
@@ -41,7 +41,8 @@ namespace VisualRust.Build
                 WorkingDirectory = cargo.WorkingDirectory,
                 Arguments = argString,
                 RedirectStandardError = true,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                StandardOutputEncoding = Encoding.UTF8
             };
 
             var process = new Process();

--- a/VisualRust.Build/CargoBuild.cs
+++ b/VisualRust.Build/CargoBuild.cs
@@ -42,7 +42,8 @@ namespace VisualRust.Build
                 Arguments = argString,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
-                StandardOutputEncoding = Encoding.UTF8
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
             };
 
             var process = new Process();

--- a/VisualRust.Build/CargoClean.cs
+++ b/VisualRust.Build/CargoClean.cs
@@ -29,7 +29,8 @@ namespace VisualRust.Build
                 WorkingDirectory = cargo.WorkingDirectory,
                 Arguments = arguments,
                 RedirectStandardError = true,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                StandardOutputEncoding = Encoding.UTF8
             };
 
             var process = new Process();

--- a/VisualRust.Build/CargoClean.cs
+++ b/VisualRust.Build/CargoClean.cs
@@ -30,7 +30,8 @@ namespace VisualRust.Build
                 Arguments = arguments,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
-                StandardOutputEncoding = Encoding.UTF8
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
             };
 
             var process = new Process();

--- a/VisualRust.Build/Rustc.cs
+++ b/VisualRust.Build/Rustc.cs
@@ -220,7 +220,8 @@ namespace VisualRust.Build
                 Arguments = argumets,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
-                StandardOutputEncoding = Encoding.UTF8
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
             };
 
             var process = new Process();

--- a/VisualRust.Build/Rustc.cs
+++ b/VisualRust.Build/Rustc.cs
@@ -219,7 +219,8 @@ namespace VisualRust.Build
                 WorkingDirectory = WorkingDirectory,
                 Arguments = argumets,
                 RedirectStandardError = true,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                StandardOutputEncoding = Encoding.UTF8
             };
 
             var process = new Process();

--- a/VisualRust.Shared/Cargo.cs
+++ b/VisualRust.Shared/Cargo.cs
@@ -101,7 +101,8 @@ namespace VisualRust.Shared
                 CreateNoWindow = true,
                 FileName = exePath,
                 RedirectStandardOutput = true,
-                Arguments = "-V"
+                Arguments = "-V",
+                StandardOutputEncoding = Encoding.UTF8
             };
             try
             {

--- a/VisualRust.Shared/Cargo.cs
+++ b/VisualRust.Shared/Cargo.cs
@@ -102,7 +102,8 @@ namespace VisualRust.Shared
                 FileName = exePath,
                 RedirectStandardOutput = true,
                 Arguments = "-V",
-                StandardOutputEncoding = Encoding.UTF8
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
             };
             try
             {

--- a/VisualRust.Shared/Environment.cs
+++ b/VisualRust.Shared/Environment.cs
@@ -59,7 +59,8 @@ namespace VisualRust.Shared
                 FileName = exePath,
                 RedirectStandardOutput = true,
                 Arguments = "-Vv",
-                StandardOutputEncoding = Encoding.UTF8
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
             };
             string verboseVersion;
             try

--- a/VisualRust.Shared/Environment.cs
+++ b/VisualRust.Shared/Environment.cs
@@ -58,7 +58,8 @@ namespace VisualRust.Shared
                 CreateNoWindow = true,
                 FileName = exePath,
                 RedirectStandardOutput = true,
-                Arguments = "-Vv"
+                Arguments = "-Vv",
+                StandardOutputEncoding = Encoding.UTF8
             };
             string verboseVersion;
             try

--- a/VisualRust/Racer/RacerSingleton.cs
+++ b/VisualRust/Racer/RacerSingleton.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 using VisualRust.Options;
 using Process = System.Diagnostics.Process;
 
@@ -114,7 +115,8 @@ namespace VisualRust.Racer
                     process.StartInfo.UseShellExecute = false;
                     process.StartInfo.RedirectStandardOutput = true;
                     process.StartInfo.CreateNoWindow = true;
-                    if(this.racerSourcesLocation != null)
+                    process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
+                    if (this.racerSourcesLocation != null)
                         process.StartInfo.EnvironmentVariables[RacerSourceEnviromentVariable] = racerSourcesLocation;
 
                     process.Start();

--- a/VisualRust/Racer/RacerSingleton.cs
+++ b/VisualRust/Racer/RacerSingleton.cs
@@ -116,6 +116,8 @@ namespace VisualRust.Racer
                     process.StartInfo.RedirectStandardOutput = true;
                     process.StartInfo.CreateNoWindow = true;
                     process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
+                    process.StartInfo.StandardErrorEncoding = Encoding.UTF8;
+
                     if (this.racerSourcesLocation != null)
                         process.StartInfo.EnvironmentVariables[RacerSourceEnviromentVariable] = racerSourcesLocation;
 


### PR DESCRIPTION
Racer, rustc and cargo use UTF8 console output. Fix some problem with non ASCII path to tools.