### PR TITLE
Add AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+version: '{build}'
+branches:
+  only:
+  - master
+skip_tags: true
+configuration:
+- Release
+install:
+- cmd: >-
+    powershell Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-msvc.exe"
+
+    rust-nightly-i686-pc-windows-msvc.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+
+    SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+
+    rustc -Vv
+
+    cargo -Vv
+before_build:
+- cmd: >-
+    git submodule update --init --recursive
+
+    nuget restore
+build:
+  project: VisualRust.sln
+  parallel: true
+  verbosity: normal
+artifacts:
+- path: VisualRust.Setup\bin\Release\*.msi
+  name: VisualRust.msi


### PR DESCRIPTION
I've removed Debug-CI as it was the configuration for non-integration tests. Since the integration tests are gone, so is the Debug-CI.

Partially fixes #238, I plan to reenable tests later.