### PR TITLE
Build and project bug fixes possibly related to Visual Studio 2017 compatibility

### DIFF
--- a/VisualRust.Build/Rustc.cs
+++ b/VisualRust.Build/Rustc.cs
@@ -373,6 +373,10 @@ namespace VisualRust.Build
             // todo all other fields
             // todo mb help key word is code.explanation
 
+            // cargo build json messages don't always contain a message component
+            if (msg == null)
+                return;
+
             var type = msg.GetLevelAsEnum();
             var primarySpan = msg.GetPrimarySpan();
             var code = msg.GetErrorCodeAsString();

--- a/VisualRust.ProjectSystem.FileSystemMirroring/IO/MsBuildFileSystemWatcher.cs
+++ b/VisualRust.ProjectSystem.FileSystemMirroring/IO/MsBuildFileSystemWatcher.cs
@@ -13,6 +13,7 @@ using VisualRust.ProjectSystem.FileSystemMirroring.Utilities;
 using System.IO.Abstractions;
 using NotifyFilters = System.IO.NotifyFilters;
 using IOException = System.IO.IOException;
+using Win32Exception = System.ComponentModel.Win32Exception;
 using ErrorEventArgs = System.IO.ErrorEventArgs;
 
 #if VS14
@@ -222,10 +223,14 @@ namespace VisualRust.ProjectSystem.FileSystemMirroring.IO {
             shortRelativePath = null;
             if (fullPath.StartsWithIgnoreCase(rootDirectory)) {
                 relativePath = PathHelper.MakeRelative(rootDirectory, fullPath);
-                 try {
+                try
+                {
                     shortRelativePath = fileSystem.ToShortRelativePath(fullPath, rootDirectory);
                     return !string.IsNullOrEmpty(shortRelativePath) && filter.IsFileAllowed(relativePath, fileSystem.FileInfo.FromFileName(fullPath).Attributes);
-                } catch (IOException) { } catch (UnauthorizedAccessException) { } // File isn't allowed if it isn't accessible
+                }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { } // File isn't allowed if it isn't accessible
+                catch (Win32Exception) { } // ToShortPath can throw a Win32Exception if the file doesn't exist anymore, which isn't exceptional
             }
             return false;
         }

--- a/VisualRust.ProjectSystem.FileSystemMirroring/Project/FileSystemMirroringProject.cs
+++ b/VisualRust.ProjectSystem.FileSystemMirroring/Project/FileSystemMirroringProject.cs
@@ -137,6 +137,7 @@ namespace VisualRust.ProjectSystem.FileSystemMirroring.Project {
             foreach (var configuredProject in _unconfiguredProject.LoadedConfiguredProjects) {
                 try {
                     var jsproj = await access.GetProjectAsync(configuredProject, cancellationToken);
+                    jsproj.MarkDirty();
                     jsproj.ReevaluateIfNecessary();
                 } catch (Exception ex) {
                     System.Diagnostics.Debug.Fail("We were unable to mark a configuration as dirty" + ex.Message, ex.StackTrace);


### PR DESCRIPTION
I've fixed a few issues I encountered whilst trying to build and use the latest version of Visual Rust.

1) When trying to build a project generated from the standard Rust Application template, MSBuild would crash, because the json-formatted feedback returned from the cargo build command didn't contain a .message component referenced in the LogRustcMessage function. I've chosen here to just exit the logging function early since there's no real message to log. I'm not sure if the information contained in the parent message object itself is perhaps relevant to the output window still.

2) When you open a file in a project and save it, the MsBuildFileSystemWatcher would produce an error, because Visual Studio 2017* briefly creates a temporary file in the project directory, and in the process of checking its relevance to the project, the MsBuildFileSystemWatcher would attempt to shorten the path of the file after the temporary file was already removed again. This causes the ToShortPath function to throw a Win32Exception that was not handled in the IsFileAllowed function. Since the file no longer exists, the accessibility of the file is a little irrelevant, so I just caught the error so the function returns false.

* Might be the case with earlier versions as well, but I've only tested it with 2017

3) The code for loading a project file from scratch sets up an empty project, and then intends to mark it as dirty before requesting a rebuild of the project tree, but never actually marks it as dirty. This means that loading an existing solution from disk yielded a tree in the Solution Explorer containing only the solution and the project itself, but none of the items contained within. It required you to unload and reload the project through the Solution Explorer to actually see the files and folders that made up the project.
