### PR TITLE
Fix Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,15 +3,16 @@ branches:
   only:
   - master
 skip_tags: true
+image: Visual Studio 2017
 configuration:
 - Release
 install:
-- cmd: >-
-    powershell Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-msvc.exe"
+- ps: >-
+    Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-msvc.exe"
 
-    rust-nightly-i686-pc-windows-msvc.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+    .\rust-nightly-i686-pc-windows-msvc.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust" /COMPONENTS="rust,cargo,std" | Out-Default
 
-    SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+    $env:Path += ";C:\Program Files (x86)\Rust\bin"
 
     rustc -Vv
 


### PR DESCRIPTION
This should bring back CI builds of Visual Rust installer. Generated version is probably slightly wrong, but it should work at least.